### PR TITLE
Modernize landing page and add links to new and classic Sudoku

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,263 @@
-<!DOCTYPE html>
-<html>
-    <head>
-        <title>My JavaScript Projects</title>
-    </head>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="#101827">
+    <meta name="description" content="A collection of small JavaScript games, from the original experiments to their modern reimaginings.">
+    <title>JavaScript Arcade</title>
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <style>
+        :root {
+            color-scheme: dark;
+            --ink: #f7f8fc;
+            --muted: #aab4c5;
+            --panel: rgba(24, 35, 53, 0.76);
+            --line: rgba(255, 255, 255, 0.11);
+            --accent: #83e6c3;
+            --accent-dark: #10271f;
+        }
 
-    <body>
-        <h1>
-            <a href="Minesweeper/index.html">Minesweeper</a>
-        </h1>
-        <h1>
-            <a href="pong/index.html">Pong</a>
-        </h1>
-        <h1>
-            <a href="Sudoku/index.html">Sudoku</a>
-        </h1>
-    </body>
+        * { box-sizing: border-box; }
+
+        body {
+            min-height: 100vh;
+            margin: 0;
+            color: var(--ink);
+            background:
+                radial-gradient(circle at 8% 0%, rgba(46, 101, 120, 0.45), transparent 34rem),
+                radial-gradient(circle at 95% 90%, rgba(81, 58, 120, 0.35), transparent 36rem),
+                #0d1420;
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        a { color: inherit; }
+
+        .shell {
+            width: min(1120px, calc(100% - 40px));
+            margin: 0 auto;
+            padding: 32px 0 64px;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 24px;
+            margin-bottom: clamp(72px, 12vw, 140px);
+        }
+
+        .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 11px;
+            font-weight: 750;
+            letter-spacing: -0.02em;
+        }
+
+        .brand-mark {
+            display: grid;
+            width: 34px;
+            height: 34px;
+            place-items: center;
+            color: #0d1420;
+            background: var(--accent);
+            border-radius: 10px;
+            font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+            font-size: 14px;
+        }
+
+        .header-note { color: var(--muted); font-size: 14px; }
+
+        .eyebrow {
+            margin: 0 0 18px;
+            color: var(--accent);
+            font-size: 12px;
+            font-weight: 800;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+        }
+
+        h1 {
+            max-width: 780px;
+            margin: 0;
+            font-size: clamp(48px, 8vw, 92px);
+            font-weight: 730;
+            letter-spacing: -0.065em;
+            line-height: 0.96;
+        }
+
+        .intro {
+            max-width: 630px;
+            margin: 28px 0 58px;
+            color: var(--muted);
+            font-size: clamp(17px, 2vw, 20px);
+            line-height: 1.65;
+        }
+
+        .game-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 18px;
+        }
+
+        .card {
+            position: relative;
+            min-height: 300px;
+            padding: clamp(26px, 4vw, 42px);
+            overflow: hidden;
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 28px;
+            box-shadow: 0 24px 70px rgba(0, 0, 0, 0.18);
+            backdrop-filter: blur(14px);
+        }
+
+        .card::after {
+            position: absolute;
+            right: -55px;
+            bottom: -75px;
+            width: 190px;
+            height: 190px;
+            background: var(--glow, rgba(131, 230, 195, 0.16));
+            border-radius: 50%;
+            content: "";
+            filter: blur(8px);
+        }
+
+        .card-featured { grid-column: 1 / -1; min-height: 330px; }
+        .card-featured .card-copy { max-width: 610px; }
+        .card:nth-child(2) { --glow: rgba(114, 157, 255, 0.18); }
+        .card:nth-child(3) { --glow: rgba(206, 132, 255, 0.18); }
+
+        .card-top {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 52px;
+        }
+
+        .game-icon {
+            display: grid;
+            width: 46px;
+            height: 46px;
+            place-items: center;
+            background: rgba(255, 255, 255, 0.07);
+            border: 1px solid var(--line);
+            border-radius: 14px;
+            font-size: 20px;
+        }
+
+        .badge {
+            padding: 7px 10px;
+            color: var(--muted);
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid var(--line);
+            border-radius: 999px;
+            font-size: 11px;
+            font-weight: 800;
+            letter-spacing: 0.09em;
+            text-transform: uppercase;
+        }
+
+        h2 { margin: 0 0 12px; font-size: clamp(30px, 4vw, 44px); letter-spacing: -0.04em; }
+        .card-copy { position: relative; z-index: 1; }
+        .card-copy p { margin: 0; color: var(--muted); line-height: 1.65; }
+
+        .actions { display: flex; flex-wrap: wrap; gap: 11px; margin-top: 28px; }
+        .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 46px;
+            padding: 0 18px;
+            border: 1px solid var(--line);
+            border-radius: 12px;
+            font-size: 14px;
+            font-weight: 750;
+            text-decoration: none;
+            transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+        }
+
+        .button-primary { color: var(--accent-dark); background: var(--accent); border-color: var(--accent); }
+        .button-secondary { background: rgba(255, 255, 255, 0.05); }
+        .button:hover { transform: translateY(-2px); border-color: rgba(255, 255, 255, 0.4); }
+        .button:focus-visible { outline: 3px solid rgba(131, 230, 195, 0.45); outline-offset: 3px; }
+        footer { margin-top: 34px; color: var(--muted); font-size: 13px; text-align: center; }
+
+        @media (max-width: 700px) {
+            .shell { width: min(100% - 28px, 1120px); padding-top: 22px; }
+            header { margin-bottom: 72px; }
+            .header-note { display: none; }
+            .intro { margin-bottom: 42px; }
+            .game-grid { grid-template-columns: 1fr; }
+            .card-featured { grid-column: auto; }
+            .card { min-height: 0; border-radius: 22px; }
+            .card-top { margin-bottom: 38px; }
+            .actions { flex-direction: column; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .button { transition: none; }
+        }
+    </style>
+</head>
+<body>
+    <main class="shell">
+        <header>
+            <div class="brand"><span class="brand-mark" aria-hidden="true">JS</span> JavaScript Arcade</div>
+            <span class="header-note">Small games, thoughtfully rebuilt.</span>
+        </header>
+
+        <section aria-labelledby="page-title">
+            <p class="eyebrow">Pick a game</p>
+            <h1 id="page-title">A little break for your brain.</h1>
+            <p class="intro">Revisit the original browser experiments or try their polished new editions. No sign-ups, no distractions—just play.</p>
+        </section>
+
+        <section class="game-grid" aria-label="Games">
+            <article class="card card-featured">
+                <div class="card-top">
+                    <span class="game-icon" aria-hidden="true">⌗</span>
+                    <span class="badge">New edition available</span>
+                </div>
+                <div class="card-copy">
+                    <h2>Sudoku</h2>
+                    <p>Slow down and find the pattern. Choose the refined new experience or revisit the original p5.js classic.</p>
+                    <div class="actions">
+                        <a class="button button-primary" href="Sudoku/index.html">Play new Sudoku&nbsp; →</a>
+                        <a class="button button-secondary" href="Sudoku/classic/index.html">Play classic Sudoku</a>
+                    </div>
+                </div>
+            </article>
+
+            <article class="card">
+                <div class="card-top">
+                    <span class="game-icon" aria-hidden="true">✦</span>
+                    <span class="badge">Modern edition coming soon</span>
+                </div>
+                <div class="card-copy">
+                    <h2>Minesweeper</h2>
+                    <p>Clear the field, read the clues, and avoid every hidden mine.</p>
+                    <div class="actions"><a class="button button-secondary" href="Minesweeper/index.html">Play the classic&nbsp; →</a></div>
+                </div>
+            </article>
+
+            <article class="card">
+                <div class="card-top">
+                    <span class="game-icon" aria-hidden="true">●</span>
+                    <span class="badge">Modern edition coming soon</span>
+                </div>
+                <div class="card-copy">
+                    <h2>Pong</h2>
+                    <p>The timeless arcade rally, reduced to its purest form.</p>
+                    <div class="actions"><a class="button button-secondary" href="pong/index.html">Play the classic&nbsp; →</a></div>
+                </div>
+            </article>
+        </section>
+
+        <footer>Built with JavaScript and a healthy sense of curiosity.</footer>
+    </main>
+</body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the minimal root index with a modern, focused landing page that highlights available games and exposes both the new and classic Sudoku experiences. 
- Present Minesweeper and Pong as playable classics while signaling that modern reworks are "coming soon". 
- Improve accessibility, responsive layout, and general polish (typography, focus styles, reduced-motion support) so the project is easier to navigate and play on modern devices. 

### Description
- Replaced `index.html` with a new dark-themed, responsive game gallery containing prominent cards for Sudoku, Minesweeper, and Pong. 
- Added direct links to the new Sudoku (`Sudoku/index.html`) and the original classic Sudoku (`Sudoku/classic/index.html`) and retained links to `Minesweeper/index.html` and `pong/index.html`. 
- Introduced enhanced page metadata and favicon, refined typography, responsive grid layout, visually distinct buttons (`.button-primary` / `.button-secondary`), and decorative gradients. 
- Added accessibility and UX improvements including visible `:focus-visible` styles, `prefers-reduced-motion` support, semantic structure, and a responsive card layout. 

### Testing
- Ran `git diff --check` to validate the working tree for whitespace/errors and it completed successfully. 
- Parsed `index.html` with Python's `HTMLParser` and verified that links to `Sudoku/index.html`, `Sudoku/classic/index.html`, `Minesweeper/index.html`, and `pong/index.html` resolve to existing files (success). 
- Verified repository status with `git status --porcelain` after committing the change (working tree clean). 
- Attempted browser-based screenshot testing via `npx --yes playwright --version`, but Playwright installation failed due to the environment's package registry returning HTTP 403, so visual/browser tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78ec5a7c7483208ff74d0f31330146)