### PR TITLE
Add touch drag controls for Pong paddles

### DIFF
--- a/pong/index.html
+++ b/pong/index.html
@@ -34,7 +34,7 @@
             <button class="secondary-button" id="pause" type="button">Pause / resume</button>
             <button class="secondary-button" id="fullscreen" type="button" aria-pressed="false">Enter full screen</button>
             <div class="touch-controls" aria-label="Touch paddle controls"><button type="button" data-key="KeyW" aria-label="Move left paddle up">↑</button><button type="button" data-key="KeyS" aria-label="Move left paddle down">↓</button></div>
-            <p class="instructions"><strong>Left paddle</strong> <kbd>W</kbd> <kbd>S</kbd><br><strong>Right paddle</strong> <kbd>↑</kbd> <kbd>↓</kbd> in two-player mode<br><kbd>Space</kbd> pauses and resumes</p>
+            <p class="instructions"><strong>Touch</strong> Drag on either half of the arena to move that side's paddle.<br><strong>Left paddle</strong> <kbd>W</kbd> <kbd>S</kbd><br><strong>Right paddle</strong> <kbd>↑</kbd> <kbd>↓</kbd> in two-player mode<br><kbd>Space</kbd> pauses and resumes</p>
         </aside>
     </section>
 </main><script src="scripts/app.js"></script>

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -14,7 +14,7 @@ const overlayHint = overlay.querySelector('span');
 const game = {
     width: 960, height: 600, running: false, paused: false, over: false, mode: 'solo',
     last: 0, serve: 1, score: [0, 0], keys: new Set(), nextPowerUp: 5, elapsed: 0,
-    lastTouch: 0, powerUps: [], effects: [{}, {}]
+    lastTouch: 0, powerUps: [], effects: [{}, {}], pointerControls: new Map()
 };
 const paddles = [
     { x: 34, y: 240, w: 14, h: 120, baseH: 120, vy: 0, color: '#fffdf8' },
@@ -88,8 +88,8 @@ function update(dt) {
     game.elapsed += dt; updatePowerUps();
     paddles.forEach((paddle, side) => { const tall = (game.effects[side].reachUntil || 0) > game.elapsed; const center = paddle.y + paddle.h / 2; paddle.h = tall ? 162 : paddle.baseH; paddle.y = center - paddle.h / 2; });
     const leftSpeed = (game.effects[0].quickUntil || 0) > game.elapsed ? 625 : 500;
-    paddles[0].vy = (game.keys.has('KeyS') ? leftSpeed : 0) - (game.keys.has('KeyW') ? leftSpeed : 0);
-    if (game.mode === 'duo') { const rightSpeed = (game.effects[1].quickUntil || 0) > game.elapsed ? 625 : 500; paddles[1].vy = (game.keys.has('ArrowDown') ? rightSpeed : 0) - (game.keys.has('ArrowUp') ? rightSpeed : 0); }
+    paddles[0].vy = game.pointerControls.has(0) ? 0 : (game.keys.has('KeyS') ? leftSpeed : 0) - (game.keys.has('KeyW') ? leftSpeed : 0);
+    if (game.mode === 'duo') { const rightSpeed = (game.effects[1].quickUntil || 0) > game.elapsed ? 625 : 500; paddles[1].vy = game.pointerControls.has(1) ? 0 : (game.keys.has('ArrowDown') ? rightSpeed : 0) - (game.keys.has('ArrowUp') ? rightSpeed : 0); }
     else { const target = game.powerUps.find(item => item.side === 1 && powerUpTypes[item.type].collection === 'paddle')?.y ?? balls[0].y; paddles[1].vy = Math.max(-370, Math.min(370, (target - paddles[1].h / 2 - paddles[1].y) * 5)); }
     paddles.forEach(paddle => paddle.y = Math.max(12, Math.min(game.height - paddle.h - 12, paddle.y + paddle.vy * dt)));
     for (const ball of balls) {
@@ -100,6 +100,36 @@ function update(dt) {
         if (ball.x < -30) { point(1); return; } if (ball.x > game.width + 30) { point(0); return; }
     }
 }
+
+function movePaddleToPointer(side, event) {
+    const paddle = paddles[side];
+    const rect = canvas.getBoundingClientRect();
+    const pointerY = (event.clientY - rect.top) * game.height / rect.height;
+    paddle.y = Math.max(12, Math.min(game.height - paddle.h - 12, pointerY - paddle.h / 2));
+}
+canvas.addEventListener('pointerdown', event => {
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    const rect = canvas.getBoundingClientRect();
+    const side = event.clientX - rect.left < rect.width / 2 ? 0 : 1;
+    if (side === 1 && game.mode !== 'duo') return;
+    if (game.pointerControls.has(side)) return;
+    event.preventDefault();
+    game.pointerControls.set(side, event.pointerId);
+    canvas.setPointerCapture(event.pointerId);
+    movePaddleToPointer(side, event);
+});
+canvas.addEventListener('pointermove', event => {
+    const side = [0, 1].find(index => game.pointerControls.get(index) === event.pointerId);
+    if (side === undefined) return;
+    event.preventDefault();
+    movePaddleToPointer(side, event);
+});
+function releasePointer(event) {
+    const side = [0, 1].find(index => game.pointerControls.get(index) === event.pointerId);
+    if (side !== undefined) game.pointerControls.delete(side);
+}
+canvas.addEventListener('pointerup', releasePointer);
+canvas.addEventListener('pointercancel', releasePointer);
 function roundedRect(x, y, width, height, radius) { ctx.beginPath(); ctx.roundRect(x, y, width, height, radius); ctx.fill(); }
 function drawPowerUp(powerUp) {
     const type = powerUpTypes[powerUp.type]; const remaining = powerUp.expires - game.elapsed; const pulse = 1 + Math.sin(game.elapsed * 7) * .06;


### PR DESCRIPTION
### Motivation
- Provide touch-friendly paddle controls so players on iPad/iPhone and other touch devices can drag their paddle. 
- Allow two simultaneous drags so two players can each control a paddle by touching their side of the screen.

### Description
- Add `pointerControls` (a `Map`) to the `game` state to track active pointer ownership per side and prevent keyboard movement while a paddle is being dragged. 
- Update `update` to respect pointer ownership by disabling keyboard-driven `vy` when a paddle is being dragged and to keep solo AI behavior when the right side is not being dragged. 
- Implement `movePaddleToPointer(side, event)` to map pointer `clientY` into canvas coordinates and clamp the paddle inside the play area. 
- Register pointer event handlers on the canvas: `pointerdown` (detect side, capture pointer, start tracking), `pointermove` (move owned paddle), and `pointerup`/`pointercancel` (release pointer ownership); right-side drags are only accepted in `duo` mode. 
- Update the instructions in `pong/index.html` to document the new drag gesture for touch users.

### Testing
- Ran `node --check pong/scripts/app.js` and it completed without syntax errors. 
- Ran a source assertion script that verifies presence of the pointer handlers, pointer ownership logic, side selection, and updated instructions, and the assertions passed. 
- Ran `git diff --check` to ensure no whitespace or diff issues; the check passed. 
- Attempted to capture a browser screenshot but no supported browser is available in the environment, so visual browser tests could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a78ff983b70832083923352279bedd7)