### PR TITLE
Add public/private online rooms, passcode support, and room browser UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ required.
 | **Sudoku** | The refreshed, responsive version with notes, hints, keyboard controls, and an animated backtracking solver. | [Play modern Sudoku](https://bashmohandes.github.io/Javascript/Sudoku/) |
 | **Sudoku Classic** | The original p5.js experiment, preserved alongside the new game. | [Play Sudoku Classic](https://bashmohandes.github.io/Javascript/Sudoku/classic/) |
 | **Minesweeper** | A canvas-based take on the classic mine-clearing puzzle. | [Play Minesweeper](https://bashmohandes.github.io/Javascript/Minesweeper/) |
-| **Pong** | Responsive solo, couch co-op, and private online multiplayer Pong. | [Play Pong](https://bashmohandes.github.io/Javascript/pong/) |
+| **Pong** | Responsive solo, couch co-op, and public or private online multiplayer Pong. | [Play Pong](https://bashmohandes.github.io/Javascript/pong/) |
 
 The repository also contains solutions and experiments from LeetCode,
 Codeforces, and Codewars.
@@ -20,8 +20,9 @@ Codeforces, and Codewars.
 
 Online Pong uses a small authoritative Node.js WebSocket server. The server owns
 the ball, paddles, power-ups, and score so both players always receive the same
-match state. Rooms are private, in memory, and disappear after all players leave
-or the inactivity timeout expires.
+match state. Public rooms appear in the in-game room browser, while private rooms
+require a 4–32 character passcode. All rooms live in memory and disappear after
+all players leave or the inactivity timeout expires.
 
 ### Docker Compose (recommended)
 
@@ -31,8 +32,10 @@ From the repository root:
 docker compose up -d --build
 ```
 
-Open `http://YOUR_NAS_IP:8080/pong/`, select **Online**, and create a room. The
-host can copy the invitation link or give the five-character code to a friend.
+Open `http://YOUR_NAS_IP:8080/pong/`, select **Online**, and join an available
+public room or create a new one. A host can list a public room for anyone to join,
+or create a passcode-protected private room and share its invitation link or
+five-character code with a friend.
 Set a different host port in a `.env` file if port 8080 is occupied:
 
 ```dotenv

--- a/pong/index.html
+++ b/pong/index.html
@@ -19,13 +19,20 @@
             <div id="status" class="status" role="status" aria-live="polite">Choose your match and start the rally.</div>
             <div class="mode-switch" aria-label="Game mode"><button type="button" data-mode="solo" aria-pressed="true">Solo</button><button type="button" data-mode="duo" aria-pressed="false">Two players</button><button type="button" data-mode="online" aria-pressed="false">Online</button></div>
             <section class="online-panel" id="online-panel" aria-labelledby="online-title" hidden>
-                <div class="online-heading"><div><span class="online-label">Private match</span><strong id="online-title">Play a friend online</strong></div><span class="connection-state" id="connection-state" data-state="offline">Offline</span></div>
+                <div class="online-heading"><div><span class="online-label">Online match</span><strong id="online-title">Find a player</strong></div><span class="connection-state" id="connection-state" data-state="offline">Offline</span></div>
                 <div id="online-lobby">
-                    <button class="primary-button" id="create-room" type="button">Create a room</button>
-                    <div class="join-row"><label for="room-code">Room code</label><div><input id="room-code" maxlength="5" autocomplete="off" autocapitalize="characters" spellcheck="false" placeholder="ABCDE"><button class="secondary-button" id="join-room" type="button">Join</button></div></div>
+                    <div class="room-browser-heading"><strong>Public rooms</strong><button class="text-button" id="refresh-rooms" type="button">Refresh</button></div>
+                    <div class="room-list" id="room-list" aria-live="polite"><p>Loading available rooms…</p></div>
+                    <div class="create-room-form">
+                        <label for="room-visibility">Create a room</label>
+                        <div class="create-row"><select id="room-visibility"><option value="public">Public — listed for everyone</option><option value="private">Private — passcode required</option></select><button class="primary-button" id="create-room" type="button">Create</button></div>
+                        <input class="passcode-input" id="create-passcode" type="password" minlength="4" maxlength="32" autocomplete="new-password" placeholder="Passcode (4–32 characters)" hidden>
+                    </div>
+                    <div class="join-row"><label for="room-code">Join with a room code</label><div><input id="room-code" maxlength="5" autocomplete="off" autocapitalize="characters" spellcheck="false" placeholder="ABCDE"><button class="secondary-button" id="join-room" type="button">Join</button></div><input class="passcode-input" id="join-passcode" type="password" maxlength="32" autocomplete="current-password" placeholder="Passcode (private rooms only)"></div>
                 </div>
                 <div id="online-room" hidden>
-                    <p class="room-copy">Room <strong id="room-code-display">—</strong></p>
+                    <div class="side-card" id="player-side"><span>You are playing</span><strong>Left side</strong><small>Use W / S or drag your paddle</small></div>
+                    <p class="room-copy"><span id="room-visibility-display">Room</span> <strong id="room-code-display">—</strong></p>
                     <div class="room-actions"><button class="secondary-button" id="copy-invite" type="button">Copy invite link</button><button class="primary-button" id="ready-online" type="button">I’m ready</button></div>
                     <button class="text-button" id="leave-room" type="button">Leave room</button>
                 </div>

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -15,6 +15,7 @@ const onlineLobby = document.querySelector('#online-lobby');
 const onlineRoom = document.querySelector('#online-room');
 const connectionState = document.querySelector('#connection-state');
 const readyOnlineButton = document.querySelector('#ready-online');
+const roomList = document.querySelector('#room-list');
 
 const game = {
     width: 960, height: 600, running: false, paused: false, over: false, mode: 'solo',
@@ -42,6 +43,43 @@ function sendOnline(message) { if (online.socket?.readyState === WebSocket.OPEN)
 function saveSession() { sessionStorage.setItem('pong-online-session', JSON.stringify({ roomCode: online.roomCode, token: online.token })); }
 function clearSession() { sessionStorage.removeItem('pong-online-session'); online.roomCode = ''; online.token = ''; }
 function showOnlineRoom(code) { onlineLobby.hidden = true; onlineRoom.hidden = false; document.querySelector('#room-code-display').textContent = code; }
+function updateOnlineIdentity() {
+    const sideName = online.side === 0 ? 'Left' : 'Right';
+    const sideCard = document.querySelector('#player-side');
+    sideCard.dataset.side = sideName.toLowerCase();
+    sideCard.querySelector('strong').textContent = `${sideName} side`;
+    document.querySelectorAll('.player-color').forEach((picker, side) => {
+        const ownPaddle = side === online.side;
+        picker.querySelector('span').textContent = ownPaddle ? `You (${sideName})` : `Opponent (${side ? 'Right' : 'Left'})`;
+        picker.toggleAttribute('aria-disabled', !ownPaddle);
+        picker.querySelector('.color-trigger').disabled = !ownPaddle;
+    });
+}
+function resetColorControls() {
+    document.querySelectorAll('.player-color').forEach((picker, side) => {
+        picker.querySelector('span').textContent = side ? 'Right' : 'Left';
+        picker.removeAttribute('aria-disabled');
+        picker.querySelector('.color-trigger').disabled = false;
+    });
+}
+async function refreshRooms() {
+    roomList.innerHTML = '<p>Loading available rooms…</p>';
+    try {
+        const response = await fetch('/api/rooms', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Unable to load rooms.');
+        const { rooms } = await response.json();
+        roomList.replaceChildren();
+        if (!rooms.length) { roomList.innerHTML = '<p>No public rooms yet. Create one and be the first to play.</p>'; return; }
+        rooms.forEach(room => {
+            const item = document.createElement('div'); item.className = 'public-room';
+            const details = document.createElement('div'); const code = document.createElement('strong'); code.textContent = room.code;
+            const players = document.createElement('span'); players.textContent = `${room.players}/2 players · Waiting`;
+            const join = document.createElement('button'); join.type = 'button'; join.className = 'secondary-button'; join.textContent = 'Join';
+            join.addEventListener('click', () => connectOnline({ type: 'join-room', roomCode: room.code }));
+            details.append(code, players); item.append(details, join); roomList.append(item);
+        });
+    } catch (error) { roomList.innerHTML = `<p>${error.message}</p>`; }
+}
 function applyOnlineState(state) {
     game.running = state.running; game.paused = state.paused; game.over = state.over; game.elapsed = state.elapsed; game.score = state.score;
     setScore(0, state.score[0]); setScore(1, state.score[1]);
@@ -52,7 +90,8 @@ function applyOnlineState(state) {
 }
 function handleOnlineMessage(message) {
     if (message.type === 'session') {
-        online.roomCode = message.roomCode; online.token = message.playerToken; online.side = message.side; saveSession(); showOnlineRoom(message.roomCode); setConnection('Connected', 'online');
+        online.roomCode = message.roomCode; online.token = message.playerToken; online.side = message.side; saveSession(); showOnlineRoom(message.roomCode); updateOnlineIdentity(); setConnection('Connected', 'online');
+        document.querySelector('#room-visibility-display').textContent = message.visibility === 'public' ? 'Public room' : 'Private room';
         const url = new URL(location.href); url.searchParams.set('room', message.roomCode); history.replaceState(null, '', url); status.textContent = message.side === 0 ? 'Room created. Share the invite and wait for your opponent.' : 'Joined room. Press “I’m ready” when set.';
     } else if (message.type === 'room-status') {
         const opponentConnected = message.players[1 - online.side];
@@ -83,7 +122,7 @@ function connectOnline(action) {
 }
 function leaveOnline(notify = true) {
     clearTimeout(online.reconnectTimer); if (notify) sendOnline({ type: 'leave' }); online.intentionalClose = true; online.socket?.close(); clearSession();
-    onlineLobby.hidden = false; onlineRoom.hidden = true; setConnection('Offline'); const url = new URL(location.href); url.searchParams.delete('room'); history.replaceState(null, '', url);
+    onlineLobby.hidden = false; onlineRoom.hidden = true; resetColorControls(); setConnection('Offline'); refreshRooms(); const url = new URL(location.href); url.searchParams.delete('room'); history.replaceState(null, '', url);
 }
 function onlineInput() { sendOnline({ type: 'input', up: game.keys.has('KeyW') || game.keys.has('ArrowUp'), down: game.keys.has('KeyS') || game.keys.has('ArrowDown'), targetY: null }); }
 
@@ -204,10 +243,12 @@ function draw() {
 }
 function frame(time) { const dt = Math.min((time - game.last) / 1000, .025) || 0; game.last = time; if (game.mode !== 'online' && game.running && !game.paused) update(dt); draw(); requestAnimationFrame(frame); }
 
-document.querySelectorAll('[data-mode]').forEach(button => button.addEventListener('click', () => { if (game.mode === 'online' && button.dataset.mode !== 'online') leaveOnline(); game.mode = button.dataset.mode; document.querySelectorAll('[data-mode]').forEach(item => item.setAttribute('aria-pressed', item === button)); onlinePanel.hidden = game.mode !== 'online'; document.querySelectorAll('.local-control').forEach(item => item.hidden = game.mode === 'online'); document.querySelector('#pause').hidden = game.mode === 'online'; if (game.mode === 'online') { game.running = false; game.paused = true; resetBall(); showOverlay('Online match', 'Create a room or join a friend'); } else newGame(); }));
+document.querySelectorAll('[data-mode]').forEach(button => button.addEventListener('click', () => { if (game.mode === 'online' && button.dataset.mode !== 'online') leaveOnline(); game.mode = button.dataset.mode; document.querySelectorAll('[data-mode]').forEach(item => item.setAttribute('aria-pressed', item === button)); onlinePanel.hidden = game.mode !== 'online'; document.querySelectorAll('.local-control').forEach(item => item.hidden = game.mode === 'online'); document.querySelector('#pause').hidden = game.mode === 'online'; if (game.mode === 'online') { game.running = false; game.paused = true; resetBall(); refreshRooms(); showOverlay('Online match', 'Choose a public room or create your own'); } else { resetColorControls(); newGame(); } }));
 document.querySelector('#new-game').addEventListener('click', newGame); document.querySelector('#pause').addEventListener('click', togglePause); overlay.addEventListener('click', togglePause);
-document.querySelector('#create-room').addEventListener('click', () => connectOnline({ type: 'create-room' }));
-document.querySelector('#join-room').addEventListener('click', () => { const roomCode = document.querySelector('#room-code').value.trim().toUpperCase(); if (roomCode.length !== 5) { status.textContent = 'Enter the five-character room code.'; return; } connectOnline({ type: 'join-room', roomCode }); });
+document.querySelector('#room-visibility').addEventListener('change', event => { document.querySelector('#create-passcode').hidden = event.target.value !== 'private'; });
+document.querySelector('#create-room').addEventListener('click', () => { const visibility = document.querySelector('#room-visibility').value; const passcode = document.querySelector('#create-passcode').value.trim(); if (visibility === 'private' && (passcode.length < 4 || passcode.length > 32)) { status.textContent = 'Choose a private room passcode between 4 and 32 characters.'; return; } connectOnline({ type: 'create-room', visibility, passcode }); });
+document.querySelector('#join-room').addEventListener('click', () => { const roomCode = document.querySelector('#room-code').value.trim().toUpperCase(); if (roomCode.length !== 5) { status.textContent = 'Enter the five-character room code.'; return; } connectOnline({ type: 'join-room', roomCode, passcode: document.querySelector('#join-passcode').value.trim() }); });
+document.querySelector('#refresh-rooms').addEventListener('click', refreshRooms);
 document.querySelector('#room-code').addEventListener('input', event => { event.target.value = event.target.value.toUpperCase().replace(/[^A-Z2-9]/g, '').slice(0, 5); });
 readyOnlineButton.addEventListener('click', () => { readyOnlineButton.disabled = true; sendOnline({ type: game.over ? 'rematch' : 'ready' }); });
 document.querySelector('#leave-room').addEventListener('click', () => leaveOnline());

--- a/pong/styles.css
+++ b/pong/styles.css
@@ -83,6 +83,20 @@ kbd { padding:2px 5px; border:1px solid var(--line); border-radius:3px; backgrou
 .connection-state { padding:5px 8px; border-radius:999px; color:var(--muted); background:var(--sage); font-size:10px; font-weight:700; }
 .connection-state[data-state="online"] { color:#246342; background:#d9eddf; }
 .connection-state[data-state="connecting"] { color:#7c5b19; background:#f4e8c8; }
+.room-browser-heading { display:flex; align-items:center; justify-content:space-between; margin-top:14px; }
+.room-browser-heading strong,.create-room-form>label { color:var(--muted); font-size:10px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
+.room-browser-heading .text-button { margin:0; }
+.room-list { display:grid; gap:7px; max-height:150px; margin-top:7px; overflow:auto; }
+.room-list>p { margin:8px 0; color:var(--muted); font-size:12px; }
+.public-room { display:flex; align-items:center; justify-content:space-between; gap:10px; padding:9px 10px; border:1px solid var(--line); border-radius:7px; background:var(--card); }
+.public-room div { display:grid; gap:2px; }
+.public-room strong { font-size:13px; letter-spacing:.12em; }
+.public-room span { color:var(--muted); font-size:10px; }
+.public-room button { width:auto; padding:8px 12px; }
+.create-room-form { display:grid; gap:6px; margin-top:14px; padding-top:14px; border-top:1px solid var(--line); }
+.create-row { display:grid; grid-template-columns:1fr auto; gap:8px; }
+.create-row select,.passcode-input { min-width:0; padding:11px; border:1px solid var(--line); border-radius:7px; color:var(--ink); background:var(--card); font:12px "DM Sans",sans-serif; }
+.create-row .primary-button { width:auto; }
 .join-row { display:grid; gap:6px; margin-top:12px; }
 .join-row label { color:var(--muted); font-size:10px; font-weight:700; letter-spacing:.08em; text-transform:uppercase; }
 .join-row>div,.room-actions { display:grid; grid-template-columns:1fr auto; gap:8px; }
@@ -90,6 +104,13 @@ kbd { padding:2px 5px; border:1px solid var(--line); border-radius:3px; backgrou
 .join-row .secondary-button,.room-actions .secondary-button,.room-actions .primary-button { width:auto; }
 .room-copy { margin:0 0 12px; color:var(--muted); font-size:13px; }
 .room-copy strong { color:var(--ink); font-size:20px; letter-spacing:.12em; }
+.side-card { display:grid; gap:2px; margin-bottom:14px; padding:12px; border-left:4px solid var(--accent); border-radius:7px; background:var(--sage); }
+.side-card[data-side="right"] { border-right:4px solid var(--accent); border-left:0; text-align:right; }
+.side-card span { color:var(--muted); font-size:9px; font-weight:700; letter-spacing:.1em; text-transform:uppercase; }
+.side-card strong { font-family:"DM Serif Display",serif; font-size:22px; font-weight:400; }
+.side-card small { color:var(--muted); font-size:10px; }
+.player-color[aria-disabled="true"] { opacity:.48; }
+.player-color[aria-disabled="true"] .color-trigger { cursor:not-allowed; }
 .text-button { margin:10px auto 0; padding:4px; border:0; color:var(--muted); background:none; font-size:11px; text-decoration:underline; cursor:pointer; }
 @media(max-width:850px){ .intro{align-items:start}.game-layout{grid-template-columns:1fr}.controls{grid-template-columns:1fr 1fr}.status,.instructions{grid-column:1/-1}.touch-controls{display:grid}.scoreboard{padding:10px 14px} }
 @media(max-width:520px){ .app-shell{width:min(100% - 20px,480px)}.topbar{height:64px}.intro{display:block;padding:34px 0 28px}.scoreboard{margin-top:24px;justify-content:center}.game-layout{gap:20px}.controls{grid-template-columns:1fr}.status,.instructions{grid-column:auto} }

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,11 @@ const server = http.createServer((request, response) => {
         response.end(JSON.stringify({ status: 'ok', rooms: rooms.rooms.size }));
         return;
     }
+    if (pathname === '/api/rooms' && request.method === 'GET') {
+        response.writeHead(200, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store' });
+        response.end(JSON.stringify({ rooms: rooms.publicRooms() }));
+        return;
+    }
     if (/^\/(?:server|tests|node_modules)(?:\/|$)/.test(pathname) || /^\/(?:package(?:-lock)?\.json|compose\.yaml|Dockerfile|project(?:\.lock)?\.json)$/.test(pathname)) {
         response.writeHead(404).end('Not found');
         return;
@@ -58,8 +63,8 @@ websocketServer.on('connection', socket => {
         let message;
         try { message = JSON.parse(raw.toString()); } catch { send(socket, { type: 'error', message: 'Invalid message.' }); return; }
         try {
-            if (!membership && message.type === 'create-room') membership = rooms.create(socket);
-            else if (!membership && message.type === 'join-room') membership = rooms.join(message.roomCode, socket);
+            if (!membership && message.type === 'create-room') membership = rooms.create(socket, { visibility: message.visibility, passcode: message.passcode });
+            else if (!membership && message.type === 'join-room') membership = rooms.join(message.roomCode, socket, message.passcode);
             else if (!membership && message.type === 'resume') membership = rooms.resume(message.roomCode, message.playerToken, socket);
             else if (!membership) throw new Error('Create or join a room first.');
             else if (message.type === 'ready' || message.type === 'rematch') {
@@ -71,7 +76,7 @@ websocketServer.on('connection', socket => {
             else throw new Error('Unsupported message type.');
 
             if (membership && ['create-room', 'join-room', 'resume'].includes(message.type)) {
-                send(socket, credentials(membership.room, membership.player));
+                send(socket, { ...credentials(membership.room, membership.player), visibility: membership.room.visibility });
                 rooms.broadcast(membership.room, { type: 'room-status', players: membership.room.players.map(player => Boolean(player?.connected)) });
                 if (message.type === 'resume') rooms.broadcast(membership.room, { type: 'peer-reconnected' });
             }

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -5,6 +5,7 @@ const { createGame, startGame, update, setInput, setColor, snapshot } = require(
 
 const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
 const token = () => crypto.randomBytes(24).toString('base64url');
+const normalizePasscode = value => String(value || '').trim();
 
 class RoomManager {
     constructor({ reconnectMs = 15000, roomTimeoutMs = 30 * 60 * 1000, random = Math.random } = {}) {
@@ -21,22 +22,33 @@ class RoomManager {
         return code;
     }
 
-    create(socket) {
+    create(socket, { visibility = 'private', passcode = '' } = {}) {
+        const isPublic = visibility === 'public';
+        const normalizedPasscode = normalizePasscode(passcode);
+        if (!isPublic && (normalizedPasscode.length < 4 || normalizedPasscode.length > 32)) throw new Error('Private room passcodes must be 4–32 characters.');
         const code = this.makeCode();
         const player = { id: token(), token: token(), side: 0, socket, connected: true, ready: false, disconnectedAt: null };
-        const room = { code, players: [player, null], game: createGame(this.random), createdAt: Date.now(), touchedAt: Date.now(), countdownUntil: null };
+        const room = { code, visibility: isPublic ? 'public' : 'private', passcode: isPublic ? '' : normalizedPasscode, players: [player, null], game: createGame(this.random), createdAt: Date.now(), touchedAt: Date.now(), countdownUntil: null };
         this.rooms.set(code, room);
         return { room, player };
     }
 
-    join(code, socket) {
+    join(code, socket, passcode = '') {
         const room = this.rooms.get(String(code || '').toUpperCase());
         if (!room) throw new Error('Room not found. Check the code and try again.');
         if (room.players[1]) throw new Error('That room is already full.');
+        if (room.visibility === 'private' && normalizePasscode(passcode) !== room.passcode) throw new Error('That passcode is incorrect.');
         const player = { id: token(), token: token(), side: 1, socket, connected: true, ready: false, disconnectedAt: null };
         room.players[1] = player;
         room.touchedAt = Date.now();
         return { room, player };
+    }
+
+    publicRooms() {
+        return Array.from(this.rooms.values())
+            .filter(room => room.visibility === 'public' && !room.players[1])
+            .sort((left, right) => right.createdAt - left.createdAt)
+            .map(room => ({ code: room.code, players: room.players.filter(player => player?.connected).length, createdAt: room.createdAt }));
     }
 
     resume(code, playerToken, socket) {

--- a/tests/rooms.test.js
+++ b/tests/rooms.test.js
@@ -8,9 +8,10 @@ function socket() { return { readyState: 1, messages: [], send(body) { this.mess
 
 test('creates, joins, readies, and expires a private room', () => {
     const rooms = new RoomManager({ reconnectMs: 100, random: () => 0.1 });
-    const host = rooms.create(socket());
+    const host = rooms.create(socket(), { passcode: 'rally7' });
     assert.equal(host.room.code.length, 5);
-    const guest = rooms.join(host.room.code, socket());
+    assert.throws(() => rooms.join(host.room.code, socket(), 'wrong'), /passcode/i);
+    const guest = rooms.join(host.room.code, socket(), 'rally7');
     assert.equal(guest.player.side, 1);
     assert.equal(rooms.ready(host.room, host.player), false);
     assert.equal(rooms.ready(host.room, guest.player), true);
@@ -23,7 +24,22 @@ test('creates, joins, readies, and expires a private room', () => {
 test('rejects unknown and full rooms', () => {
     const rooms = new RoomManager({ random: () => 0.2 });
     assert.throws(() => rooms.join('NOPE1', socket()), /not found/i);
-    const host = rooms.create(socket());
+    const host = rooms.create(socket(), { visibility: 'public' });
     rooms.join(host.room.code, socket());
     assert.throws(() => rooms.join(host.room.code, socket()), /full/i);
+});
+
+test('lists only open public rooms without exposing private rooms', () => {
+    const rooms = new RoomManager();
+    const publicRoom = rooms.create(socket(), { visibility: 'public' });
+    rooms.create(socket(), { visibility: 'private', passcode: 'secret' });
+    assert.deepEqual(rooms.publicRooms().map(room => room.code), [publicRoom.room.code]);
+    rooms.join(publicRoom.room.code, socket());
+    assert.deepEqual(rooms.publicRooms(), []);
+});
+
+test('requires a valid passcode when creating private rooms', () => {
+    const rooms = new RoomManager();
+    assert.throws(() => rooms.create(socket()), /4.*32 characters/);
+    assert.throws(() => rooms.create(socket(), { passcode: 'abc' }), /4.*32 characters/);
 });


### PR DESCRIPTION
### Motivation
- Provide a discoverable online experience by allowing public rooms to be listed and enabling private, passcode-protected rooms so players can easily find or invite opponents.

### Description
- Add a `GET /api/rooms` endpoint and include room `visibility` in WebSocket session responses so the client can display public room listings.
- Extend the server `RoomManager` to persist `visibility` and normalized `passcode`, validate passcodes on create/join, and expose a `publicRooms()` method to list open public rooms.
- Update WebSocket handling to accept `visibility` and `passcode` when creating or joining rooms and to return visibility in session credentials.
- Update the client (`pong/index.html`, `pong/styles.css`, `pong/scripts/app.js`) to provide a room browser, create-room form with public/private toggle and passcode input, refresh/join public rooms, display player side and disable opponent color controls, and refresh the UI state on leave/enter online mode.

### Testing
- Ran the unit tests with the Node test runner (`node test`) and all tests in `tests/rooms.test.js` passed.
- New tests were added and executed to validate private room creation/joining, passcode validation, public room listing, and rejection of unknown or full rooms, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7928ff1bd08320ad00749749aa8c31)