### PR TITLE
Add PWA icons/manifest and icon generator; wire into CI and Docker

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,14 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
       - name: Install locked dependencies
         run: npm ci
+      - name: Generate installable app icons
+        run: npm run generate:icons
       - name: Audit production dependencies
         run: npm audit --omit=dev
       - name: Run tests
@@ -39,7 +41,7 @@ jobs:
     needs: test
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build container without publishing
@@ -57,7 +59,7 @@ jobs:
     needs: [test, build]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .DS_Store
 bin
 obj
+
+# Generated from icon.svg by scripts/generate-icons.js. Keeping these build
+# artifacts out of Git allows source-only pull requests while still providing
+# the raster formats required by iOS and installable web apps.
+apple-touch-icon.png
+icon-192.png
+icon-512.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV NODE_ENV=production PORT=8080
 WORKDIR /app
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY . .
-RUN chown -R node:node /app
+RUN npm run generate:icons && chown -R node:node /app
 USER node
 EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \

--- a/Minesweeper/index.html
+++ b/Minesweeper/index.html
@@ -6,8 +6,13 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/tile.js" type="text/javascript"></script>
-        <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-        <link rel="icon" href="/favicon.ico" type="image/x-icon">
+        <link rel="icon" href="../icon.svg" type="image/svg+xml">
+        <link rel="icon" href="../favicon.ico" sizes="any">
+        <link rel="apple-touch-icon" href="../apple-touch-icon.png" sizes="180x180">
+        <link rel="manifest" href="../manifest.webmanifest">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="apple-mobile-web-app-title" content="JS Arcade">
     </head>
 
     <body>

--- a/Sudoku/classic/index.html
+++ b/Sudoku/classic/index.html
@@ -4,7 +4,13 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Sudoku Classic</title>
-    <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
+    <link rel="icon" href="../../icon.svg" type="image/svg+xml">
+    <link rel="icon" href="../../favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="../../apple-touch-icon.png" sizes="180x180">
+    <link rel="manifest" href="../../manifest.webmanifest">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="JS Arcade">
     <style>
         body { margin: 0; padding: 24px; color: #222; background: #f4f4f4; font-family: Arial, sans-serif; }
         header { display: flex; align-items: center; justify-content: space-between; width: 630px; max-width: 100%; margin-bottom: 16px; }

--- a/Sudoku/index.html
+++ b/Sudoku/index.html
@@ -5,7 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#f5f1e8">
     <title>Sudoku · Daily focus</title>
-    <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon">
+    <link rel="icon" href="../icon.svg" type="image/svg+xml">
+    <link rel="icon" href="../favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="../apple-touch-icon.png" sizes="180x180">
+    <link rel="manifest" href="../manifest.webmanifest">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="JS Arcade">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title">
+  <title id="title">JavaScript Arcade</title>
+  <rect width="512" height="512" fill="#0d1420"/>
+  <circle cx="88" cy="82" r="132" fill="#1f5260" opacity=".72"/>
+  <circle cx="448" cy="442" r="152" fill="#493568" opacity=".72"/>
+  <rect x="94" y="94" width="324" height="324" rx="92" fill="#83e6c3"/>
+  <path fill="#0d1420" d="M143 158h105v142c0 43-25 68-67 68-23 0-42-8-56-24l30-38c8 9 16 14 25 14 12 0 18-8 18-24V205h-55zm138 40c0-28 23-46 59-46 27 0 48 9 64 27l-31 36c-11-11-22-16-34-16-8 0-13 3-13 8 0 7 10 11 29 18 35 13 54 34 54 68 0 47-31 75-80 75-30 0-56-11-75-33l32-38c13 15 28 23 44 23 13 0 20-5 20-14 0-8-10-13-29-20-35-13-50-33-50-58z"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,13 @@
     <meta name="theme-color" content="#101827">
     <meta name="description" content="A collection of small JavaScript games, from the original experiments to their modern reimaginings.">
     <title>JavaScript Arcade</title>
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" href="icon.svg" type="image/svg+xml">
+    <link rel="icon" href="favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" sizes="180x180">
+    <link rel="manifest" href="manifest.webmanifest">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="JS Arcade">
     <style>
         :root {
             color-scheme: dark;

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "JavaScript Arcade",
+  "short_name": "JS Arcade",
+  "description": "A collection of thoughtfully rebuilt browser games.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#0d1420",
+  "theme_color": "#101827",
+  "icons": [
+    {
+      "src": "icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "main": "server/index.js",
   "scripts": {
     "start": "node server/index.js",
+    "prestart": "npm run generate:icons",
     "dev": "node --watch server/index.js",
+    "generate:icons": "node scripts/generate-icons.js",
     "test": "node --test",
-    "check": "node --check server/index.js && node --check server/game.js && node --check server/rooms.js && node --check pong/scripts/app.js",
+    "check": "node --check server/index.js && node --check server/game.js && node --check server/rooms.js && node --check pong/scripts/app.js && node --check scripts/generate-icons.js",
     "audit": "npm audit --omit=dev"
   },
   "engines": {

--- a/pong/classic/index.html
+++ b/pong/classic/index.html
@@ -7,8 +7,13 @@
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/board.js" type="text/javascript"></script>
         <script src="scripts/ball.js" type="text/javascript"></script>
-        <link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon">
-        <link rel="icon" href="../../favicon.ico" type="image/x-icon">
+        <link rel="icon" href="../../icon.svg" type="image/svg+xml">
+        <link rel="icon" href="../../favicon.ico" sizes="any">
+        <link rel="apple-touch-icon" href="../../apple-touch-icon.png" sizes="180x180">
+        <link rel="manifest" href="../../manifest.webmanifest">
+        <meta name="apple-mobile-web-app-capable" content="yes">
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+        <meta name="apple-mobile-web-app-title" content="JS Arcade">
     </head>
 
     <body>

--- a/pong/index.html
+++ b/pong/index.html
@@ -3,7 +3,14 @@
 <head>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="theme-color" content="#f5f1e8">
     <meta name="description" content="A polished, responsive take on the original arcade Pong."><title>Pong · Keep the rally alive</title>
-    <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon"><link rel="stylesheet" href="styles.css">
+    <link rel="icon" href="../icon.svg" type="image/svg+xml">
+    <link rel="icon" href="../favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="../apple-touch-icon.png" sizes="180x180">
+    <link rel="manifest" href="../manifest.webmanifest">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="JS Arcade">
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
 <main class="app-shell">

--- a/scripts/generate-icons.js
+++ b/scripts/generate-icons.js
@@ -1,0 +1,124 @@
+'use strict';
+
+// Raster app icons are generated rather than committed because this repository's
+// pull-request tooling accepts text patches only. The vector source remains in
+// icon.svg; this dependency-free renderer reproduces its palette and JS mark.
+const fs = require('node:fs');
+const zlib = require('node:zlib');
+
+const colors = {
+    background: [13, 20, 32],
+    teal: [31, 82, 96],
+    purple: [73, 53, 104],
+    mint: [131, 230, 195]
+};
+const glyphs = {
+    J: ['11111', '00100', '00100', '00100', '00100', '10100', '01100'],
+    S: ['01111', '10000', '10000', '01110', '00001', '00001', '11110']
+};
+
+function crc32(buffer) {
+    let crc = 0xffffffff;
+    for (const byte of buffer) {
+        crc ^= byte;
+        for (let bit = 0; bit < 8; bit += 1) crc = (crc >>> 1) ^ ((crc & 1) ? 0xedb88320 : 0);
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data) {
+    const name = Buffer.from(type);
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(data.length);
+    const checksum = Buffer.alloc(4);
+    checksum.writeUInt32BE(crc32(Buffer.concat([name, data])));
+    return Buffer.concat([length, name, data, checksum]);
+}
+
+function encodePng(size, pixels) {
+    const header = Buffer.alloc(13);
+    header.writeUInt32BE(size, 0);
+    header.writeUInt32BE(size, 4);
+    header.set([8, 2, 0, 0, 0], 8);
+    const rows = [];
+    for (let y = 0; y < size; y += 1) {
+        rows.push(Buffer.from([0]), pixels.subarray(y * size * 3, (y + 1) * size * 3));
+    }
+    return Buffer.concat([
+        Buffer.from('89504e470d0a1a0a', 'hex'),
+        pngChunk('IHDR', header),
+        pngChunk('IDAT', zlib.deflateSync(Buffer.concat(rows), { level: 9 })),
+        pngChunk('IEND', Buffer.alloc(0))
+    ]);
+}
+
+function renderIcon(size) {
+    const scale = 3;
+    const canvasSize = size * scale;
+    const pixels = Buffer.alloc(canvasSize * canvasSize * 3);
+    for (let index = 0; index < pixels.length; index += 3) pixels.set(colors.background, index);
+
+    function setPixel(x, y, color) {
+        if (x < 0 || y < 0 || x >= canvasSize || y >= canvasSize) return;
+        pixels.set(color, (y * canvasSize + x) * 3);
+    }
+
+    function circle(cx, cy, radius, color) {
+        cx *= scale; cy *= scale; radius *= scale;
+        for (let y = Math.max(0, Math.floor(cy - radius)); y < Math.min(canvasSize, Math.ceil(cy + radius)); y += 1) {
+            const offset = Math.sqrt(Math.max(0, radius ** 2 - (y + 0.5 - cy) ** 2));
+            for (let x = Math.max(0, Math.floor(cx - offset)); x < Math.min(canvasSize, Math.ceil(cx + offset)); x += 1) setPixel(x, y, color);
+        }
+    }
+
+    function roundedRectangle(left, top, right, bottom, radius, color) {
+        left *= scale; top *= scale; right *= scale; bottom *= scale; radius *= scale;
+        for (let y = Math.floor(top); y < Math.ceil(bottom); y += 1) {
+            for (let x = Math.floor(left); x < Math.ceil(right); x += 1) {
+                const dx = Math.max(left + radius - (x + 0.5), 0, x + 0.5 - (right - radius));
+                const dy = Math.max(top + radius - (y + 0.5), 0, y + 0.5 - (bottom - radius));
+                if (dx ** 2 + dy ** 2 <= radius ** 2) setPixel(x, y, color);
+            }
+        }
+    }
+
+    circle(size * 0.17, size * 0.16, size * 0.26, colors.teal);
+    circle(size * 0.88, size * 0.86, size * 0.3, colors.purple);
+    roundedRectangle(size * 0.183, size * 0.183, size * 0.817, size * 0.817, size * 0.18, colors.mint);
+
+    const cell = size * 0.052;
+    const gap = size * 0.035;
+    let offsetX = (size - (10 * cell + gap)) / 2;
+    const offsetY = size * 0.31;
+    for (const character of 'JS') {
+        glyphs[character].forEach((row, y) => [...row].forEach((filled, x) => {
+            if (filled === '1') roundedRectangle(
+                offsetX + x * cell, offsetY + y * cell,
+                offsetX + (x + 1) * cell + 0.5, offsetY + (y + 1) * cell + 0.5,
+                cell * 0.12, colors.background
+            );
+        }));
+        offsetX += 5 * cell + gap;
+    }
+
+    const output = Buffer.alloc(size * size * 3);
+    for (let y = 0; y < size; y += 1) {
+        for (let x = 0; x < size; x += 1) {
+            const totals = [0, 0, 0];
+            for (let sourceY = y * scale; sourceY < (y + 1) * scale; sourceY += 1) {
+                for (let sourceX = x * scale; sourceX < (x + 1) * scale; sourceX += 1) {
+                    const index = (sourceY * canvasSize + sourceX) * 3;
+                    for (let channel = 0; channel < 3; channel += 1) totals[channel] += pixels[index + channel];
+                }
+            }
+            const index = (y * size + x) * 3;
+            for (let channel = 0; channel < 3; channel += 1) output[index + channel] = Math.floor(totals[channel] / scale ** 2);
+        }
+    }
+    return encodePng(size, output);
+}
+
+for (const [filename, size] of [['apple-touch-icon.png', 180], ['icon-192.png', 192], ['icon-512.png', 512]]) {
+    fs.writeFileSync(filename, renderIcon(size));
+    console.log(`Generated ${filename} (${size}x${size})`);
+}

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,16 @@ const rooms = new RoomManager({
     reconnectMs: Number(process.env.RECONNECT_GRACE_MS) || 15000,
     roomTimeoutMs: Number(process.env.ROOM_TIMEOUT_MS) || 1800000
 });
-const mime = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8', '.css': 'text/css; charset=utf-8', '.ico': 'image/x-icon', '.json': 'application/json; charset=utf-8' };
+const mime = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.ico': 'image/x-icon',
+    '.png': 'image/png',
+    '.svg': 'image/svg+xml',
+    '.webmanifest': 'application/manifest+json; charset=utf-8',
+    '.json': 'application/json; charset=utf-8'
+};
 
 const server = http.createServer((request, response) => {
     const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);


### PR DESCRIPTION
### Motivation

- Provide first-class app icons and a web manifest so the site can be installed as a PWA and display proper favicons across platforms.  
- Keep raster icon artifacts out of source control while still producing PNG outputs for iOS and installable web apps.  
- Ensure CI and container builds produce the required raster assets automatically rather than relying on committed binaries.

### Description

- Add a vector source `icon.svg` and a dependency-free generator `scripts/generate-icons.js` that emits `apple-touch-icon.png`, `icon-192.png`, and `icon-512.png`.  
- Update top-level and game HTML files to reference `icon.svg`, the generated PNGs, `manifest.webmanifest`, and PWA meta tags for Apple and installable web apps.  
- Add `manifest.webmanifest` describing `icon-192`/`icon-512`, and add the generated raster filenames to `.gitignore`.  
- Wire icon generation into the project lifecycle by adding `generate:icons` and `prestart` scripts to `package.json`, invoking the generator in the `Dockerfile`, and adding a `npm run generate:icons` step to the GitHub Actions `container.yml`; also bump Action versions and `setup-node` to v5 and update the server MIME map to serve `.png`, `.svg`, and `.webmanifest` correctly.

### Testing

- Ran the CI workflow that executes `npm ci`, `npm test`, `npm run check` (now including `scripts/generate-icons.js`) and the build job which ran Docker Buildx, and the steps completed successfully.  
- Verified the generator produces `apple-touch-icon.png`, `icon-192.png`, and `icon-512.png` during the test/build steps without additional dependencies.  
- Executed the container build step (`docker/build-push-action` with `push:false`) in CI and the image build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a792c87e77c8320834ba1676127c751)