### PR TITLE
Fix Pong iPad layout and fullscreen mode

### DIFF
--- a/pong/index.html
+++ b/pong/index.html
@@ -6,10 +6,10 @@
     <link rel="icon" href="../icon.svg" type="image/svg+xml">
     <link rel="icon" href="../favicon.ico" sizes="any">
     <link rel="apple-touch-icon" href="../apple-touch-icon.png" sizes="180x180">
-    <link rel="manifest" href="../manifest.webmanifest">
+    <link rel="manifest" href="manifest.webmanifest">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="JS Arcade">
+    <meta name="apple-mobile-web-app-title" content="Pong">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/pong/manifest.webmanifest
+++ b/pong/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "id": "./",
+  "name": "Pong",
+  "short_name": "Pong",
+  "description": "A polished, responsive take on the original arcade Pong.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "fullscreen",
+  "display_override": ["fullscreen", "standalone"],
+  "orientation": "any",
+  "background_color": "#f7f3eb",
+  "theme_color": "#f5f1e8",
+  "icons": [
+    {
+      "src": "../icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "../icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -259,9 +259,26 @@ document.querySelectorAll('.player-color').forEach((picker, index) => {
     paddleColors.forEach(color => { const swatch = document.createElement('button'); swatch.type = 'button'; swatch.className = 'swatch'; swatch.style.setProperty('--swatch', color.value); swatch.setAttribute('aria-label', `${color.name} ${index ? 'right' : 'left'} paddle`); swatch.setAttribute('aria-pressed', paddles[index].color === color.value); swatch.addEventListener('click', () => { if (game.mode === 'online' && index !== online.side) return; paddles[index].color = color.value; if (game.mode === 'online') sendOnline({ type: 'color', color: color.value }); trigger.style.setProperty('--selected-color', color.value); palette.querySelectorAll('.swatch').forEach(button => button.setAttribute('aria-pressed', button === swatch)); menu.hidden = true; trigger.setAttribute('aria-expanded', false); trigger.focus(); draw(); }); palette.append(swatch); });
 });
 document.addEventListener('click', event => { if (!event.target.closest('.player-color')) { document.querySelectorAll('.color-menu').forEach(menu => menu.hidden = true); document.querySelectorAll('.color-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', false)); } });
-fullscreenButton.addEventListener('click', async () => { if (document.fullscreenElement) await document.exitFullscreen(); else await arena.requestFullscreen(); });
-document.addEventListener('fullscreenchange', () => { const active = document.fullscreenElement === arena; fullscreenButton.textContent = active ? 'Exit full screen' : 'Enter full screen'; fullscreenButton.setAttribute('aria-pressed', active); });
-addEventListener('keydown', event => { if (event.code === 'Escape') { document.querySelectorAll('.color-menu').forEach(menu => menu.hidden = true); document.querySelectorAll('.color-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', false)); return; } if (['ArrowUp', 'ArrowDown', 'Space'].includes(event.code)) event.preventDefault(); if (event.code === 'Space') { togglePause(); return; } game.keys.add(event.code); if (game.mode === 'online') onlineInput(); }); addEventListener('keyup', event => { game.keys.delete(event.code); if (game.mode === 'online') onlineInput(); });
+function setFullscreenState(active) {
+    arena.classList.toggle('is-fullscreen', active && document.fullscreenElement !== arena);
+    document.body.classList.toggle('arena-fullscreen', active);
+    fullscreenButton.textContent = active ? 'Exit full screen' : 'Enter full screen';
+    fullscreenButton.setAttribute('aria-pressed', active);
+}
+fullscreenButton.addEventListener('click', async () => {
+    const active = document.fullscreenElement === arena || arena.classList.contains('is-fullscreen');
+    if (active) {
+        if (document.fullscreenElement) await document.exitFullscreen();
+        else setFullscreenState(false);
+        return;
+    }
+    if (arena.requestFullscreen) {
+        try { await arena.requestFullscreen(); return; } catch { /* iOS home-screen apps need the CSS fallback. */ }
+    }
+    setFullscreenState(true);
+});
+document.addEventListener('fullscreenchange', () => setFullscreenState(document.fullscreenElement === arena));
+addEventListener('keydown', event => { if (event.code === 'Escape') { document.querySelectorAll('.color-menu').forEach(menu => menu.hidden = true); document.querySelectorAll('.color-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', false)); if (arena.classList.contains('is-fullscreen')) setFullscreenState(false); return; } if (['ArrowUp', 'ArrowDown', 'Space'].includes(event.code)) event.preventDefault(); if (event.code === 'Space') { togglePause(); return; } game.keys.add(event.code); if (game.mode === 'online') onlineInput(); }); addEventListener('keyup', event => { game.keys.delete(event.code); if (game.mode === 'online') onlineInput(); });
 document.querySelectorAll('[data-key]').forEach(button => { const key = button.dataset.key; const on = event => { event.preventDefault(); game.keys.add(key); if (game.mode === 'online') onlineInput(); }; const off = event => { event.preventDefault(); game.keys.delete(key); if (game.mode === 'online') onlineInput(); }; button.addEventListener('pointerdown', on); button.addEventListener('pointerup', off); button.addEventListener('pointercancel', off); button.addEventListener('pointerleave', off); });
 addEventListener('resize', resize); resize(); requestAnimationFrame(frame);
 const invitedRoom = new URLSearchParams(location.search).get('room');

--- a/pong/styles.css
+++ b/pong/styles.css
@@ -2,7 +2,9 @@
 
 :root { --ink:#20352f; --muted:#6d7d76; --paper:#f7f3eb; --card:#fffdf8; --line:#c9d0c9; --accent:#d76b45; --accent-dark:#b84f2c; --sage:#dce5dc; }
 * { box-sizing:border-box; }
-body { margin:0; min-height:100vh; color:var(--ink); background:radial-gradient(circle at 12% 8%,rgba(215,107,69,.08),transparent 30rem),var(--paper); font-family:"DM Sans",sans-serif; }
+html,body { min-height:100%; }
+body { margin:0; min-height:100vh; min-height:100dvh; color:var(--ink); background:radial-gradient(circle at 12% 8%,rgba(215,107,69,.08),transparent 30rem),var(--paper); font-family:"DM Sans",sans-serif; }
+body.arena-fullscreen { overflow:hidden; }
 button { color:inherit; font:inherit; }
 .app-shell { width:min(1120px,calc(100% - 40px)); margin:0 auto; padding-bottom:56px; }
 .topbar { height:82px; display:flex; align-items:center; justify-content:space-between; border-bottom:1px solid rgba(32,53,47,.12); }
@@ -70,6 +72,10 @@ canvas { display:block; width:100%; aspect-ratio:16/10; touch-action:none; }
 .arena-wrap:fullscreen canvas { width:min(100vw,160vh); height:auto; }
 .arena-wrap:fullscreen .arena-score { display:block; width:min(100vw,160vh); height:min(100vh,62.5vw); top:50%; left:50%; transform:translate(-50%,-50%); }
 .arena-wrap:fullscreen .arena-message { z-index:3; }
+.arena-wrap.is-fullscreen { position:fixed; z-index:100; inset:0; display:grid; width:100vw; height:100vh; height:100dvh; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left); place-items:center; border:0; border-radius:0; background:#14251f; }
+.arena-wrap.is-fullscreen canvas { width:min(100vw,160vh); width:min(100vw,160dvh); height:auto; }
+.arena-wrap.is-fullscreen .arena-score { display:block; width:min(100vw,160vh); width:min(100vw,160dvh); height:min(100vh,62.5vw); height:min(100dvh,62.5vw); top:50%; left:50%; transform:translate(-50%,-50%); }
+.arena-wrap.is-fullscreen .arena-message { z-index:3; }
 .instructions { padding-top:17px; border-top:1px solid var(--line); color:var(--muted); font-size:12px; line-height:1.8; }
 .instructions strong { color:var(--ink); }
 kbd { padding:2px 5px; border:1px solid var(--line); border-radius:3px; background:var(--card); font-family:inherit; }
@@ -114,4 +120,28 @@ kbd { padding:2px 5px; border:1px solid var(--line); border-radius:3px; backgrou
 .text-button { margin:10px auto 0; padding:4px; border:0; color:var(--muted); background:none; font-size:11px; text-decoration:underline; cursor:pointer; }
 @media(max-width:850px){ .intro{align-items:start}.game-layout{grid-template-columns:1fr}.controls{grid-template-columns:1fr 1fr}.status,.instructions{grid-column:1/-1}.touch-controls{display:grid}.scoreboard{padding:10px 14px} }
 @media(max-width:520px){ .app-shell{width:min(100% - 20px,480px)}.topbar{height:64px}.intro{display:block;padding:34px 0 28px}.scoreboard{margin-top:24px;justify-content:center}.game-layout{gap:20px}.controls{grid-template-columns:1fr}.status,.instructions{grid-column:auto} }
+@media (min-width:851px) and (max-width:1180px), (min-width:851px) and (max-height:900px) {
+    .app-shell { width:min(1180px,calc(100% - 32px)); height:100vh; height:100dvh; padding-bottom:16px; overflow:hidden; }
+    .topbar { height:62px; }
+    .intro { align-items:center; gap:24px; padding:20px 0; }
+    .eyebrow { margin-bottom:5px; }
+    h1 { font-size:clamp(38px,5vw,54px); }
+    .intro-copy { max-width:500px; margin-top:8px; line-height:1.4; }
+    .scoreboard { flex:none; padding:8px 14px; }
+    .score strong { font-size:28px; }
+    .game-layout { height:calc(100dvh - 204px); min-height:0; grid-template-columns:minmax(0,1fr) minmax(230px,300px); gap:clamp(18px,3vw,36px); align-items:start; }
+    .arena-wrap { width:min(100%,calc((100dvh - 204px) * 1.6)); align-self:start; }
+    .controls { max-height:100%; gap:12px; padding-right:4px; overflow-y:auto; overscroll-behavior:contain; }
+    .status { min-height:18px; }
+    .primary-button,.secondary-button { padding:11px 14px; }
+    .instructions { margin:0; padding-top:10px; line-height:1.5; }
+}
+@media (min-width:521px) and (max-width:850px) {
+    .app-shell { width:min(100% - 28px,800px); }
+    .topbar { height:64px; }
+    .intro { padding:22px 0 20px; }
+    h1 { font-size:clamp(40px,7vw,54px); }
+    .intro-copy { margin-top:8px; line-height:1.4; }
+    .game-layout { gap:22px; }
+}
 @media(prefers-reduced-motion:reduce){*{transition:none!important}}


### PR DESCRIPTION
### Motivation
- The Pong page was overflowing on iPad and other short viewports so the pitch sat partially below the fold and required scrolling.
- Adding the game to the home screen broke expected fullscreen behavior in some environments (home-screen apps / iOS), so a robust fallback was needed in addition to the native Fullscreen API.

### Description
- Added a Pong-specific install manifest `pong/manifest.webmanifest` and updated the page to reference it and set the home-screen app title to "Pong".
- Tightened the layout with CSS changes in `pong/styles.css` to use dynamic viewport units, reduce header/intro spacing on tablet/short viewports, and pin the layout so the arena and controls fit without page scrolling.
- Implemented an iOS-friendly fullscreen fallback by adding `.arena-wrap.is-fullscreen` and `body.arena-fullscreen` styles and media-query adjustments to keep the pitch visible on iPad-sized screens.
- Updated `pong/scripts/app.js` to introduce `setFullscreenState`, attempt the native Fullscreen API first, and fall back to the CSS fullscreen mode when the API is unavailable; pressing Escape exits the fallback fullscreen.

### Testing
- Ran `npm test`, which passed all game tests (7 passed, 0 failed).
- Ran `npm run check` which validated the server and `pong/scripts/app.js` without errors.
- Parsed `pong/manifest.webmanifest` with Node JSON parsing to verify validity and it succeeded.
- Ran `npm run generate:icons` to produce required raster icons and confirmed the icons exist.
- `git diff --check` reported no problems for the changed files.
- Attempting `npx playwright install chromium` failed with an HTTP 403 from the package registry so no browser-based screenshot tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7932d3a918832082cca88125b04e5f)