### PR TITLE
Update Minesweeper arcade card on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,12 +241,15 @@
             <article class="card">
                 <div class="card-top">
                     <span class="game-icon" aria-hidden="true">✦</span>
-                    <span class="badge">Modern edition coming soon</span>
+                    <span class="badge">New edition available</span>
                 </div>
                 <div class="card-copy">
                     <h2>Minesweeper</h2>
-                    <p>Clear the field, read the clues, and avoid every hidden mine.</p>
-                    <div class="actions"><a class="button button-secondary" href="Minesweeper/index.html">Play the classic&nbsp; →</a></div>
+                    <p>Clear the field, read the clues, and avoid every hidden mine in the modernized game—or revisit the original experiment.</p>
+                    <div class="actions">
+                        <a class="button button-primary" href="Minesweeper/index.html">Play new Minesweeper&nbsp; →</a>
+                        <a class="button button-secondary" href="Minesweeper/classic/index.html">Play classic Minesweeper</a>
+                    </div>
                 </div>
             </article>
 


### PR DESCRIPTION
### Motivation
- Surface the modernized Minesweeper edition on the arcade index so it matches the presentation used for other updated games.

### Description
- Change the Minesweeper card badge from "Modern edition coming soon" to "New edition available" in `index.html`.
- Update the card copy to mention the modernized game while preserving the original experiment link in `index.html`.
- Add a primary action linking to `Minesweeper/index.html` and a secondary action linking to `Minesweeper/classic/index.html` so both editions are accessible.

### Testing
- `git diff --check` completed without issues.
- `npm test` ran the test suite and all 7 tests passed.
- `npm run check` (the repository `node --check` validations) completed successfully.
- Attempting to install Playwright with `npx --yes playwright@1.54.2 install chromium` failed with an HTTP 403 from the package registry, so headless browser screenshot verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a793a02717483208f78a50ef3b7c0a9)