### PR TITLE
Validate Sudoku moves against board constraints

### DIFF
--- a/Sudoku/scripts/app.js
+++ b/Sudoku/scripts/app.js
@@ -161,10 +161,10 @@
             render();
             return;
         }
-        if (solution[row][column] !== number) {
+        if (!isPlacementValid(values, row, column, number)) {
             mistakes += 1;
             mistakesElement.textContent = mistakes;
-            statusElement.textContent = mistakes >= 3 ? 'Three mistakes — start a fresh puzzle when you’re ready.' : 'Not quite. Check the row, column and box.';
+            statusElement.textContent = mistakes >= 3 ? 'Three mistakes — start a fresh puzzle when you’re ready.' : 'That number already appears in the row, column or box.';
             const cell = boardElement.querySelector(`[data-row="${row}"][data-column="${column}"]`);
             cell.classList.add('error');
             if (mistakes >= 3) endGame(false);
@@ -175,7 +175,7 @@
         removePeerNotes(row, column, number);
         statusElement.textContent = 'Nice. Keep going.';
         render();
-        if (values.every((boardRow, rowIndex) => boardRow.every((value, columnIndex) => value === solution[rowIndex][columnIndex]))) endGame(true);
+        if (values.every(boardRow => boardRow.every(Boolean))) endGame(true);
     }
 
     function removePeerNotes(row, column, number) {
@@ -339,7 +339,10 @@
     }
 
     function isSolverCandidateValid(grid, row, column) {
-        const value = grid[row][column];
+        return isPlacementValid(grid, row, column, grid[row][column]);
+    }
+
+    function isPlacementValid(grid, row, column, value) {
         for (let index = 0; index < 9; index++) {
             if (index !== column && grid[row][index] === value) return false;
             if (index !== row && grid[index][column] === value) return false;

--- a/Sudoku/tests/browser-smoke.js
+++ b/Sudoku/tests/browser-smoke.js
@@ -112,6 +112,39 @@ assert.equal(board.children.length, 81, 'renders all 81 grid cells');
 assert.equal(numberPad.children.length, 9, 'renders all nine number controls');
 assert.equal(board.children.filter(cell => cell.classList.contains('given')).length, 36, 'medium puzzle has 36 given cells');
 
+const boardValue = (row, column) => {
+    const label = board.children[row * 9 + column].getAttribute('aria-label');
+    return label.endsWith('empty') ? 0 : Number(label.match(/, (\d)/)[1]);
+};
+const candidatesFor = (row, column) => Array.from({ length: 9 }, (_, index) => index + 1).filter(number => {
+    for (let index = 0; index < 9; index++) {
+        if (boardValue(row, index) === number || boardValue(index, column) === number) return false;
+    }
+    const boxRow = Math.floor(row / 3) * 3;
+    const boxColumn = Math.floor(column / 3) * 3;
+    for (let rowIndex = boxRow; rowIndex < boxRow + 3; rowIndex++) {
+        for (let columnIndex = boxColumn; columnIndex < boxColumn + 3; columnIndex++) {
+            if (boardValue(rowIndex, columnIndex) === number) return false;
+        }
+    }
+    return true;
+});
+let trialCell;
+for (let row = 0; row < 9 && !trialCell; row++) {
+    for (let column = 0; column < 9; column++) {
+        if (!boardValue(row, column)) {
+            const candidates = candidatesFor(row, column);
+            if (candidates.length > 1) trialCell = { row, column, candidates };
+        }
+    }
+}
+assert(trialCell, 'generated puzzle has a cell with multiple currently valid candidates');
+board.children[trialCell.row * 9 + trialCell.column].click();
+numberPad.children[trialCell.candidates[0] - 1].click();
+numberPad.children[trialCell.candidates[1] - 1].click();
+assert.equal(elements.get('#mistakes').textContent, '0', 'does not penalize alternate candidates that obey Sudoku constraints');
+assert.equal(board.children[trialCell.row * 9 + trialCell.column].textContent, trialCell.candidates[1], 'allows a player to revise a valid trial entry');
+
 const emptyCell = board.children.find(cell => cell.getAttribute('aria-label').endsWith('empty'));
 emptyCell.click();
 notes.click();


### PR DESCRIPTION
### Motivation
- Prevent players from being marked incorrect when they enter a number that is locally valid in the current row, column, and 3×3 box even if it differs from the pre-generated solution.
- Keep the solver and player move validation consistent and accept any fully filled board produced by valid placements.

### Description
- Replace direct solution comparison in `enterNumber` with a shared placement check `isPlacementValid(grid, row, column, value)` and update the error message to explain a constraint conflict.
- Add `isPlacementValid` and make `isSolverCandidateValid` delegate to it so solver and player validation use the same logic.
- Change completion detection to treat any fully filled board as complete by checking `values.every(boardRow => boardRow.every(Boolean))`.
- Extend the DOM smoke test in `Sudoku/tests/browser-smoke.js` to find a cell with multiple currently valid candidates, try two different valid entries, and assert that switching candidates does not increment the mistake count and allows revising the entry.

### Testing
- Ran `git diff --check` and reported no issues.
- Ran `npm test` and all repository tests passed.
- Ran `npm run check` and the Node syntax checks passed.
- Executed the Sudoku DOM smoke test (`node Sudoku/tests/browser-smoke.js`) and a 50-run randomized loop; all smoke-test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a793cd9a35483208d681d45b903bb8f)