### PR TITLE
Keep Sudoku hints consistent with player moves and validate completed boards

### DIFF
--- a/Sudoku/scripts/app.js
+++ b/Sudoku/scripts/app.js
@@ -17,7 +17,6 @@
         stop: '<svg class="tool-icon" aria-hidden="true" focusable="false" viewBox="0 0 24 24"><rect class="tool-icon-fill" x="6" y="6" width="12" height="12" rx="1"/></svg>'
     };
 
-    let solution = [];
     let puzzle = [];
     let values = [];
     let notes = [];
@@ -63,7 +62,6 @@
     function startGame() {
         const difficulty = difficultySelect.value;
         const generated = createPuzzle(difficulty);
-        solution = generated.completed;
         puzzle = generated.playable;
         values = puzzle.map(row => [...row]);
         notes = Array.from({ length: 9 }, () => Array.from({ length: 9 }, () => new Set()));
@@ -175,7 +173,7 @@
         removePeerNotes(row, column, number);
         statusElement.textContent = 'Nice. Keep going.';
         render();
-        if (values.every(boardRow => boardRow.every(Boolean))) endGame(true);
+        if (isGridCompleteAndValid(values)) endGame(true);
     }
 
     function removePeerNotes(row, column, number) {
@@ -193,15 +191,21 @@
     }
 
     function giveHint() {
-        if (!selected || puzzle[selected.row][selected.column] || gameOver || autoSolving) {
+        if (!selected || puzzle[selected.row][selected.column] || values[selected.row][selected.column] || gameOver || autoSolving) {
             statusElement.textContent = 'Select an empty square to use a hint.';
             return;
         }
         if (!hints) { statusElement.textContent = 'You’ve used all three hints.'; return; }
         const { row, column } = selected;
-        values[row][column] = solution[row][column];
+        const currentSolution = solveGrid(values);
+        if (!currentSolution) {
+            statusElement.textContent = 'No hint fits the current board. Try revising one of your entries.';
+            return;
+        }
+        const hint = currentSolution[row][column];
+        values[row][column] = hint;
         notes[row][column].clear();
-        removePeerNotes(row, column, solution[row][column]);
+        removePeerNotes(row, column, hint);
         hints -= 1;
         document.querySelector('#hint').innerHTML = `${CONTROL_ICONS.hint}Hint <small>${hints} left</small>`;
         statusElement.textContent = 'A little nudge in the right direction.';
@@ -355,6 +359,44 @@
             }
         }
         return true;
+    }
+
+    function isGridCompleteAndValid(grid) {
+        return grid.every((gridRow, row) => gridRow.every((value, column) =>
+            value >= 1 && value <= 9 && isPlacementValid(grid, row, column, value)));
+    }
+
+    function solveGrid(grid) {
+        const candidateGrid = grid.map(row => [...row]);
+        for (let row = 0; row < 9; row++) {
+            for (let column = 0; column < 9; column++) {
+                const value = candidateGrid[row][column];
+                if (value && !isPlacementValid(candidateGrid, row, column, value)) return null;
+            }
+        }
+
+        function fillNextCell() {
+            let emptyCell = null;
+            for (let row = 0; row < 9 && !emptyCell; row++) {
+                for (let column = 0; column < 9; column++) {
+                    if (!candidateGrid[row][column]) {
+                        emptyCell = { row, column };
+                        break;
+                    }
+                }
+            }
+            if (!emptyCell) return true;
+
+            for (let value = 1; value <= 9; value++) {
+                if (!isPlacementValid(candidateGrid, emptyCell.row, emptyCell.column, value)) continue;
+                candidateGrid[emptyCell.row][emptyCell.column] = value;
+                if (fillNextCell()) return true;
+            }
+            candidateGrid[emptyCell.row][emptyCell.column] = 0;
+            return false;
+        }
+
+        return fillNextCell() ? candidateGrid : null;
     }
 
     function moveSelection(rowChange, columnChange) {

--- a/Sudoku/tests/browser-smoke.js
+++ b/Sudoku/tests/browser-smoke.js
@@ -145,6 +145,24 @@ numberPad.children[trialCell.candidates[1] - 1].click();
 assert.equal(elements.get('#mistakes').textContent, '0', 'does not penalize alternate candidates that obey Sudoku constraints');
 assert.equal(board.children[trialCell.row * 9 + trialCell.column].textContent, trialCell.candidates[1], 'allows a player to revise a valid trial entry');
 
+const trialValue = trialCell.candidates[1];
+const emptyPeer = board.children.find(cell => {
+    const row = Number(cell.dataset.row);
+    const column = Number(cell.dataset.column);
+    const sharesBox = Math.floor(row / 3) === Math.floor(trialCell.row / 3)
+        && Math.floor(column / 3) === Math.floor(trialCell.column / 3);
+    return cell.getAttribute('aria-label').endsWith('empty')
+        && (row === trialCell.row || column === trialCell.column || sharesBox);
+});
+assert(emptyPeer, 'alternate candidate has an empty peer where a hint can be requested');
+emptyPeer.click();
+elements.get('#hint').click();
+const hintedValue = boardValue(Number(emptyPeer.dataset.row), Number(emptyPeer.dataset.column));
+assert(hintedValue === 0 || hintedValue !== trialValue, 'hint never duplicates an existing value in its row, column or box');
+if (!hintedValue) {
+    assert.equal(elements.get('#status').textContent, 'No hint fits the current board. Try revising one of your entries.', 'explains when valid-looking entries leave no consistent hint');
+}
+
 const emptyCell = board.children.find(cell => cell.getAttribute('aria-label').endsWith('empty'));
 emptyCell.click();
 notes.click();


### PR DESCRIPTION
### Motivation
- Prevent the game from declaring victory for a fully-filled board that violates Sudoku constraints and avoid hints that introduce duplicates when the player has entered a locally valid alternate digit.

### Description
- Replace the previous fullness-only completion check with `isGridCompleteAndValid(grid)` so every filled cell is verified against row, column, and box constraints before calling `endGame(true)`.
- Change `giveHint` to refuse overwriting an existing player entry and to compute a `currentSolution` from the player’s current grid using a new `solveGrid` backtracking helper, returning a hint consistent with the current board or explaining when no hint fits.
- Add `solveGrid` (backtracking solver) and `isGridCompleteAndValid`, and make solver candidate validation use the shared `isPlacementValid` helper to keep solver and player checks consistent.
- Update `Sudoku/tests/browser-smoke.js` to reproduce the alternate-entry / peer-hint scenario and assert that requesting a hint never duplicates an existing peer value and that a helpful message appears when no hint is possible.

### Testing
- Ran `npm test` and all repository unit tests passed.
- Ran `npm run check` and Node syntax checks (including `node --check Sudoku/scripts/app.js`) passed.
- Executed the Sudoku DOM smoke test with `node Sudoku/tests/browser-smoke.js` and confirmed it passed.
- Performed a 50-run randomized loop of the Sudoku smoke test and `git diff --check`, all of which passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a795938b29c8320ab725fd5c9f18b54)