### PR TITLE
Add touch-accessible exit to Pong fullscreen

### DIFF
--- a/pong/index.html
+++ b/pong/index.html
@@ -21,6 +21,7 @@
             <canvas id="game" width="960" height="600" aria-label="Pong game arena"></canvas>
             <div class="arena-score" aria-hidden="true"><span id="arena-score-left">0</span><i>—</i><span id="arena-score-right">0</span></div>
             <button class="arena-message" id="arena-message" type="button"><strong>Ready to rally?</strong><span>Click or press Space to serve</span></button>
+            <button class="fullscreen-exit" id="fullscreen-exit" type="button">Exit full screen</button>
         </div>
         <aside class="controls" aria-label="Game controls">
             <div id="status" class="status" role="status" aria-live="polite">Choose your match and start the rally.</div>

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -6,6 +6,7 @@ const arenaScoreLeft = document.querySelector('#arena-score-left');
 const arenaScoreRight = document.querySelector('#arena-score-right');
 const arena = document.querySelector('#arena');
 const fullscreenButton = document.querySelector('#fullscreen');
+const fullscreenExitButton = document.querySelector('#fullscreen-exit');
 const status = document.querySelector('#status');
 const overlay = document.querySelector('#arena-message');
 const overlayTitle = overlay.querySelector('strong');
@@ -265,11 +266,14 @@ function setFullscreenState(active) {
     fullscreenButton.textContent = active ? 'Exit full screen' : 'Enter full screen';
     fullscreenButton.setAttribute('aria-pressed', active);
 }
+async function exitFullscreen() {
+    if (document.fullscreenElement) await document.exitFullscreen();
+    else setFullscreenState(false);
+}
 fullscreenButton.addEventListener('click', async () => {
     const active = document.fullscreenElement === arena || arena.classList.contains('is-fullscreen');
     if (active) {
-        if (document.fullscreenElement) await document.exitFullscreen();
-        else setFullscreenState(false);
+        await exitFullscreen();
         return;
     }
     if (arena.requestFullscreen) {
@@ -277,6 +281,7 @@ fullscreenButton.addEventListener('click', async () => {
     }
     setFullscreenState(true);
 });
+fullscreenExitButton.addEventListener('click', exitFullscreen);
 document.addEventListener('fullscreenchange', () => setFullscreenState(document.fullscreenElement === arena));
 addEventListener('keydown', event => { if (event.code === 'Escape') { document.querySelectorAll('.color-menu').forEach(menu => menu.hidden = true); document.querySelectorAll('.color-trigger').forEach(trigger => trigger.setAttribute('aria-expanded', false)); if (arena.classList.contains('is-fullscreen')) setFullscreenState(false); return; } if (['ArrowUp', 'ArrowDown', 'Space'].includes(event.code)) event.preventDefault(); if (event.code === 'Space') { togglePause(); return; } game.keys.add(event.code); if (game.mode === 'online') onlineInput(); }); addEventListener('keyup', event => { game.keys.delete(event.code); if (game.mode === 'online') onlineInput(); });
 document.querySelectorAll('[data-key]').forEach(button => { const key = button.dataset.key; const on = event => { event.preventDefault(); game.keys.add(key); if (game.mode === 'online') onlineInput(); }; const off = event => { event.preventDefault(); game.keys.delete(key); if (game.mode === 'online') onlineInput(); }; button.addEventListener('pointerdown', on); button.addEventListener('pointerup', off); button.addEventListener('pointercancel', off); button.addEventListener('pointerleave', off); });

--- a/pong/styles.css
+++ b/pong/styles.css
@@ -72,6 +72,9 @@ canvas { display:block; width:100%; aspect-ratio:16/10; touch-action:none; }
 .arena-wrap:fullscreen canvas { width:min(100vw,160vh); height:auto; }
 .arena-wrap:fullscreen .arena-score { display:block; width:min(100vw,160vh); height:min(100vh,62.5vw); top:50%; left:50%; transform:translate(-50%,-50%); }
 .arena-wrap:fullscreen .arena-message { z-index:3; }
+.fullscreen-exit { display:none; position:absolute; z-index:4; top:max(16px,env(safe-area-inset-top)); right:max(16px,env(safe-area-inset-right)); padding:11px 15px; border:1px solid rgba(255,255,255,.55); border-radius:7px; color:white; background:rgba(20,37,31,.82); font-size:12px; font-weight:700; cursor:pointer; }
+.arena-wrap:fullscreen .fullscreen-exit,.arena-wrap.is-fullscreen .fullscreen-exit { display:block; }
+.fullscreen-exit:focus-visible { outline:3px solid white; outline-offset:3px; }
 .arena-wrap.is-fullscreen { position:fixed; z-index:100; inset:0; display:grid; width:100vw; height:100vh; height:100dvh; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left); place-items:center; border:0; border-radius:0; background:#14251f; }
 .arena-wrap.is-fullscreen canvas { width:min(100vw,160vh); width:min(100vw,160dvh); height:auto; }
 .arena-wrap.is-fullscreen .arena-score { display:block; width:min(100vw,160vh); width:min(100vw,160dvh); height:min(100vh,62.5vw); height:min(100dvh,62.5vw); top:50%; left:50%; transform:translate(-50%,-50%); }


### PR DESCRIPTION
### Motivation
- Touch-only iPad / PWA environments can enter a CSS-based fullscreen fallback that covers the page controls and traps users without a hardware keyboard, so an in-arena exit affordance is required to let them leave fullscreen.

### Description
- Added an in-arena `Exit full screen` button to `pong/index.html` so touch users have a visible exit control inside the fixed arena. 
- Added `.fullscreen-exit` styles and made the button visible in both native fullscreen and the CSS fallback in `pong/styles.css`. 
- Centralized exit behavior in `pong/scripts/app.js` by introducing `exitFullscreen()` and wiring the new in-arena button to share the same exit logic as the existing fullscreen control. 
- Modified the fullscreen state handling so the UI label and `aria-pressed` state remain consistent between native and CSS fallback fullscreen modes.

### Testing
- Ran `npm test` and all tests passed (`7 passed, 0 failed`).
- Ran `npm run check` and static checks completed without errors for the modified files.
- Ran `git diff --check` (no issues) and verified the changed files are staged and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79596fe88c8320a9bb4a45ab7eb0bf)