### PR TITLE
Fix Pong readiness handling, harden static server, and add HTTP tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git
+.env
+.env.*
 .github
 .devcontainer
 node_modules

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -58,7 +58,11 @@ function handleOnlineMessage(message) {
         const opponentConnected = message.players[1 - online.side];
         status.textContent = opponentConnected ? 'Opponent connected. Both players can ready up.' : 'Waiting for your opponent to join…';
     } else if (message.type === 'match-started') { readyOnlineButton.disabled = false; readyOnlineButton.textContent = 'Ready for rematch'; status.textContent = 'First to 7. The match is live!'; }
-    else if (message.type === 'waiting-ready') { readyOnlineButton.disabled = true; readyOnlineButton.textContent = 'Waiting…'; status.textContent = 'Ready. Waiting for your opponent.'; }
+    else if (message.type === 'waiting-ready') {
+        if (message.side === online.side) {
+            readyOnlineButton.disabled = true; readyOnlineButton.textContent = 'Waiting…'; status.textContent = 'Ready. Waiting for your opponent.';
+        } else status.textContent = 'Opponent ready. Press “I’m ready” when set.';
+    }
     else if (message.type === 'state' && message.sequence > online.lastSequence) { online.lastSequence = message.sequence; applyOnlineState(message.state); }
     else if (message.type === 'peer-left') { setConnection('Reconnecting…', 'connecting'); status.textContent = `Opponent disconnected. Holding the match for ${Math.round(message.reconnectMs / 1000)} seconds.`; showOverlay('Opponent disconnected', 'The match will resume if they reconnect'); }
     else if (message.type === 'peer-reconnected') { setConnection('Connected', 'online'); status.textContent = 'Opponent reconnected. Match resumed.'; overlay.hidden = true; }

--- a/server/index.js
+++ b/server/index.js
@@ -14,15 +14,28 @@ const rooms = new RoomManager({
     roomTimeoutMs: Number(process.env.ROOM_TIMEOUT_MS) || 1800000
 });
 const mime = { '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8', '.css': 'text/css; charset=utf-8', '.ico': 'image/x-icon', '.json': 'application/json; charset=utf-8' };
+const publicDirectories = new Set(['Minesweeper', 'Sudoku', 'pong']);
+
+function requestPath(request, response) {
+    try {
+        return decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+    } catch {
+        response.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' }).end('Bad request');
+        return null;
+    }
+}
 
 const server = http.createServer((request, response) => {
-    const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+    const pathname = requestPath(request, response);
+    if (pathname === null) return;
     if (pathname === '/healthz') {
         response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
         response.end(JSON.stringify({ status: 'ok', rooms: rooms.rooms.size }));
         return;
     }
-    if (/^\/(?:server|tests|node_modules)(?:\/|$)/.test(pathname) || /^\/(?:package(?:-lock)?\.json|compose\.yaml|Dockerfile|project(?:\.lock)?\.json)$/.test(pathname)) {
+    const segments = pathname.split('/').filter(Boolean);
+    const isPublicPath = pathname === '/' || pathname === '/index.html' || pathname === '/favicon.ico' || publicDirectories.has(segments[0]);
+    if (!isPublicPath || segments.some(segment => segment.startsWith('.') || /[\0-\x1f]/.test(segment))) {
         response.writeHead(404).end('Not found');
         return;
     }

--- a/tests/server-http.test.js
+++ b/tests/server-http.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+const { after, before, test } = require('node:test');
+const path = require('node:path');
+
+let child;
+let port;
+
+function get(pathname) {
+    return new Promise((resolve, reject) => {
+        const request = http.get({ host: '127.0.0.1', port, path: pathname }, response => {
+            let body = '';
+            response.setEncoding('utf8');
+            response.on('data', chunk => { body += chunk; });
+            response.on('end', () => resolve({ status: response.statusCode, body }));
+        });
+        request.on('error', reject);
+    });
+}
+
+before(async () => {
+    port = await new Promise((resolve, reject) => {
+        const probe = net.createServer();
+        probe.once('error', reject);
+        probe.listen(0, '127.0.0.1', () => {
+            const availablePort = probe.address().port;
+            probe.close(error => error ? reject(error) : resolve(availablePort));
+        });
+    });
+
+    child = spawn(process.execPath, ['server/index.js'], {
+        cwd: path.resolve(__dirname, '..'),
+        env: { ...process.env, PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+    await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error('Server did not start')), 5000);
+        child.once('exit', code => reject(new Error(`Server exited with code ${code}`)));
+        child.stdout.on('data', chunk => {
+            if (chunk.toString().includes('JavaScript Playground listening')) {
+                clearTimeout(timeout);
+                resolve();
+            }
+        });
+    });
+});
+
+after(() => {
+    child?.kill('SIGTERM');
+});
+
+test('malformed percent escapes return 400 without stopping the server', async () => {
+    assert.equal((await get('/%')).status, 400);
+    assert.equal((await get('/healthz')).status, 200);
+});
+
+test('only explicit public assets are served', async () => {
+    assert.equal((await get('/pong/index.html')).status, 200);
+    assert.equal((await get('/.git/config')).status, 404);
+    assert.equal((await get('/.env')).status, 404);
+    assert.equal((await get('/package.json')).status, 404);
+});


### PR DESCRIPTION
### Motivation
- Prevent the online Pong UI from disabling both players' ready buttons when one player readies so matches can start reliably.
- Avoid server crashes caused by malformed percent-escapes in request paths and prevent accidental disclosure of repo/config files via static serving.
- Ensure Docker builds do not accidentally include `.env` files and add automated coverage for the corrected HTTP behavior.

### Description
- Update `pong/scripts/app.js` so the `waiting-ready` event only disables the ready button for the player identified by `message.side` and shows a different status message to the opponent.
- Add a guarded `requestPath` helper in `server/index.js` that wraps `decodeURIComponent` in a `try/catch` and returns HTTP `400` for malformed percent escapes instead of letting the process throw.
- Replace the permissive denylist approach with an explicit public allowlist in `server/index.js` so only `/`, `/index.html`, `/favicon.ico`, and top-level public game directories (`Minesweeper`, `Sudoku`, `pong`) are served, and reject hidden/unsafe path segments.
- Exclude `.env` and `.env.*` from the Docker build context by updating `.dockerignore` and add an HTTP integration test file `tests/server-http.test.js` that verifies malformed URLs return `400` and private repository/config paths return `404` while game assets remain accessible.

### Testing
- Ran `npm test` (which runs `node --test`) and all tests passed, including the new HTTP tests (`7` tests passed).
- Ran `npm run check` (JS syntax checks via `node --check`) and it completed successfully with no errors reported.
- The new HTTP integration tests assert that `GET /%` yields `400` and that sensitive paths such as `/.git/config`, `/.env`, and `/package.json` return `404` while ` /pong/index.html` returns `200`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7959a6c6d4832096a86bca89baa603)