### PR TITLE
Improve online ready flow and disconnect handling; harden pong physics; optimize Minesweeper reveal flood-fill

### DIFF
--- a/Minesweeper/scripts/app.js
+++ b/Minesweeper/scripts/app.js
@@ -45,12 +45,29 @@
     function reveal(index) {
         if (ended || cells[index].flagged || cells[index].revealed) return;
         if (!started) placeMines(index);
-        const cell = cells[index]; cell.revealed = true;
-        if (cell.mine) { endGame(false, index); return; }
-        if (!cell.count) neighboursOf(index).forEach(reveal);
+        if (cells[index].mine) { cells[index].revealed = true; endGame(false, index); return; }
+
+        // Reveal empty regions in one pass. Recursively calling reveal used to
+        // rebuild the entire board once per cleared cell, which was especially
+        // expensive on the 30-column field and could also run win checks while
+        // a flood fill was still in progress.
+        const pending = [index];
+        const queued = new Set(pending);
+        while (pending.length) {
+            const currentIndex = pending.pop();
+            const cell = cells[currentIndex];
+            if (cell.revealed || cell.flagged || cell.mine) continue;
+            cell.revealed = true;
+            if (!cell.count) neighboursOf(currentIndex).forEach(neighbour => {
+                if (!queued.has(neighbour) && !cells[neighbour].revealed && !cells[neighbour].flagged && !cells[neighbour].mine) {
+                    queued.add(neighbour);
+                    pending.push(neighbour);
+                }
+            });
+        }
         statusElement.textContent = 'The field is opening up. Keep going.';
         if (cells.every(item => item.mine || item.revealed)) endGame(true);
-        render();
+        else render();
     }
 
     function toggleFlag(index) {

--- a/pong/scripts/app.js
+++ b/pong/scripts/app.js
@@ -85,8 +85,16 @@ function applyOnlineState(state) {
     setScore(0, state.score[0]); setScore(1, state.score[1]);
     state.paddles.forEach((paddle, side) => Object.assign(paddles[side], paddle));
     balls = state.balls.map(ball => ({ ...ball })); game.powerUps = state.powerUps.map(powerUp => ({ ...powerUp }));
-    if (state.over) { const won = state.winner === online.side; status.textContent = won ? 'You won the online match!' : 'Your opponent won the online match.'; showOverlay(won ? 'You win!' : 'Opponent wins', 'Choose rematch when you are ready'); readyOnlineButton.textContent = 'Ready for rematch'; }
+    if (state.over) { const won = state.winner === online.side; status.textContent = won ? 'You won the online match!' : 'Your opponent won the online match.'; showOverlay(won ? 'You win!' : 'Opponent wins', 'Choose rematch when you are ready'); readyOnlineButton.disabled = false; readyOnlineButton.textContent = 'Ready for rematch'; }
     else if (state.running && !state.paused) overlay.hidden = true;
+}
+function applyReadyStatus(ready = []) {
+    const ownReady = Boolean(ready[online.side]);
+    const opponentReady = Boolean(ready[1 - online.side]);
+    readyOnlineButton.disabled = ownReady;
+    readyOnlineButton.textContent = ownReady ? 'Waiting…' : 'I’m ready';
+    if (ownReady) status.textContent = opponentReady ? 'Starting the match…' : 'Ready. Waiting for your opponent.';
+    else if (opponentReady) status.textContent = 'Your opponent is ready. Press “I’m ready” to start.';
 }
 function handleOnlineMessage(message) {
     if (message.type === 'session') {
@@ -95,9 +103,16 @@ function handleOnlineMessage(message) {
         const url = new URL(location.href); url.searchParams.set('room', message.roomCode); history.replaceState(null, '', url); status.textContent = message.side === 0 ? 'Room created. Share the invite and wait for your opponent.' : 'Joined room. Press “I’m ready” when set.';
     } else if (message.type === 'room-status') {
         const opponentConnected = message.players[1 - online.side];
-        status.textContent = opponentConnected ? 'Opponent connected. Both players can ready up.' : 'Waiting for your opponent to join…';
-    } else if (message.type === 'match-started') { readyOnlineButton.disabled = false; readyOnlineButton.textContent = 'Ready for rematch'; status.textContent = 'First to 7. The match is live!'; }
-    else if (message.type === 'waiting-ready') { readyOnlineButton.disabled = true; readyOnlineButton.textContent = 'Waiting…'; status.textContent = 'Ready. Waiting for your opponent.'; }
+        if (opponentConnected) {
+            applyReadyStatus(message.ready);
+            if (!message.ready?.some(Boolean)) status.textContent = 'Opponent connected. Both players can ready up.';
+        } else {
+            readyOnlineButton.disabled = false;
+            readyOnlineButton.textContent = 'I’m ready';
+            status.textContent = 'Waiting for your opponent to join…';
+        }
+    } else if (message.type === 'match-started') { readyOnlineButton.disabled = true; readyOnlineButton.textContent = 'Match in progress'; status.textContent = 'First to 7. The match is live!'; }
+    else if (message.type === 'ready-status') applyReadyStatus(message.ready);
     else if (message.type === 'state' && message.sequence > online.lastSequence) { online.lastSequence = message.sequence; applyOnlineState(message.state); }
     else if (message.type === 'peer-left') { setConnection('Reconnecting…', 'connecting'); status.textContent = `Opponent disconnected. Holding the match for ${Math.round(message.reconnectMs / 1000)} seconds.`; showOverlay('Opponent disconnected', 'The match will resume if they reconnect'); }
     else if (message.type === 'peer-reconnected') { setConnection('Connected', 'online'); status.textContent = 'Opponent reconnected. Match resumed.'; overlay.hidden = true; }

--- a/server/game.js
+++ b/server/game.js
@@ -38,11 +38,13 @@ function startGame(game) {
     game.running = true;
     game.paused = false;
     game.over = false;
+    game.winner = undefined;
     game.score = [0, 0];
     game.elapsed = 0;
     game.nextPowerUp = 5;
     game.powerUps = [];
     game.effects = [{}, {}];
+    game.inputs = [{ up: false, down: false, targetY: null }, { up: false, down: false, targetY: null }];
     game.paddles.forEach(paddle => { paddle.y = 240; paddle.h = paddle.baseH; });
     resetBall(game, game.serve, 0.75);
 }
@@ -122,9 +124,8 @@ function point(game, side) {
     } else resetBall(game, side === 0 ? 1 : -1);
 }
 
-function update(game, dt) {
+function updateStep(game, step) {
     if (!game.running || game.paused || game.over) return;
-    const step = Math.min(Math.max(dt, 0), 0.05);
     game.elapsed += step;
     if (game.serveIn > 0) {
         game.serveIn -= step;
@@ -171,6 +172,18 @@ function update(game, dt) {
         });
         if (ball.x < -30) { point(game, 1); return; }
         if (ball.x > WIDTH + 30) { point(game, 0); return; }
+    }
+}
+
+function update(game, dt) {
+    // Preserve elapsed simulation time during ordinary event-loop stalls while
+    // keeping each physics step small enough that a fast ball cannot tunnel
+    // through a paddle. Cap very long stalls to avoid a spiral of death.
+    let remaining = Math.min(Math.max(Number.isFinite(dt) ? dt : 0, 0), 0.25);
+    while (remaining > 0 && game.running && !game.paused && !game.over) {
+        const step = Math.min(remaining, 1 / 120);
+        updateStep(game, step);
+        remaining -= step;
     }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -72,29 +72,36 @@ websocketServer.on('connection', socket => {
         let message;
         try { message = JSON.parse(raw.toString()); } catch { send(socket, { type: 'error', message: 'Invalid message.' }); return; }
         try {
+            if (membership && membership.player.socket !== socket) throw new Error('This connection has been replaced by a newer session.');
             if (!membership && message.type === 'create-room') membership = rooms.create(socket, { visibility: message.visibility, passcode: message.passcode });
             else if (!membership && message.type === 'join-room') membership = rooms.join(message.roomCode, socket, message.passcode);
             else if (!membership && message.type === 'resume') membership = rooms.resume(message.roomCode, message.playerToken, socket);
             else if (!membership) throw new Error('Create or join a room first.');
             else if (message.type === 'ready' || message.type === 'rematch') {
                 const started = rooms.ready(membership.room, membership.player);
-                rooms.broadcast(membership.room, { type: started ? 'match-started' : 'waiting-ready', side: membership.player.side });
+                if (started) rooms.broadcast(membership.room, { type: 'match-started' });
+                else rooms.broadcast(membership.room, { type: 'ready-status', ready: membership.room.players.map(player => Boolean(player?.ready)) });
             } else if (message.type === 'input') rooms.input(membership.room, membership.player, message);
             else if (message.type === 'color') { rooms.color(membership.room, membership.player, message.color); rooms.broadcast(membership.room, { type: 'color', side: membership.player.side, color: message.color }); }
-            else if (message.type === 'leave') { rooms.disconnect(membership.room, membership.player); rooms.broadcast(membership.room, { type: 'peer-left', reconnectMs: rooms.reconnectMs }); membership = null; }
+            else if (message.type === 'leave') { rooms.disconnect(membership.room, membership.player, socket); rooms.broadcast(membership.room, { type: 'peer-left', reconnectMs: rooms.reconnectMs }); membership = null; }
             else throw new Error('Unsupported message type.');
 
             if (membership && ['create-room', 'join-room', 'resume'].includes(message.type)) {
                 send(socket, { ...credentials(membership.room, membership.player), visibility: membership.room.visibility });
-                rooms.broadcast(membership.room, { type: 'room-status', players: membership.room.players.map(player => Boolean(player?.connected)) });
+                rooms.broadcast(membership.room, {
+                    type: 'room-status',
+                    players: membership.room.players.map(player => Boolean(player?.connected)),
+                    ready: membership.room.players.map(player => Boolean(player?.ready))
+                });
                 if (message.type === 'resume') rooms.broadcast(membership.room, { type: 'peer-reconnected' });
             }
         } catch (error) { send(socket, { type: 'error', message: error.message }); }
     });
     socket.on('close', () => {
         if (!membership) return;
-        rooms.disconnect(membership.room, membership.player);
-        rooms.broadcast(membership.room, { type: 'peer-left', reconnectMs: rooms.reconnectMs });
+        if (rooms.disconnect(membership.room, membership.player, socket)) {
+            rooms.broadcast(membership.room, { type: 'peer-left', reconnectMs: rooms.reconnectMs });
+        }
     });
 });
 

--- a/server/rooms.js
+++ b/server/rooms.js
@@ -65,6 +65,7 @@ class RoomManager {
     }
 
     ready(room, player) {
+        if (room.game.running && !room.game.over) throw new Error('The match is already in progress.');
         player.ready = true;
         if (room.players.every(candidate => candidate?.ready && candidate.connected)) {
             room.players.forEach(candidate => { candidate.ready = false; });
@@ -74,12 +75,16 @@ class RoomManager {
         return false;
     }
 
-    disconnect(room, player) {
+    disconnect(room, player, socket = player.socket) {
+        // A resumed session replaces the player's socket. The delayed close
+        // event from the old connection must not disconnect the new one.
+        if (player.socket !== socket) return false;
         player.connected = false;
         player.socket = null;
         player.disconnectedAt = Date.now();
         room.touchedAt = Date.now();
         if (room.game.running) room.game.paused = true;
+        return true;
     }
 
     tick(dt, now = Date.now()) {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -34,3 +34,46 @@ test('ends the match when a player reaches seven', () => {
     assert.equal(game.over, true);
     assert.equal(game.winner, 1);
 });
+
+test('simulates ordinary event-loop stalls without dropping game time', () => {
+    const game = createGame(() => 0.5);
+    startGame(game);
+    game.serveIn = 0;
+    game.balls[0].vx = 100;
+
+    update(game, 0.2);
+
+    assert.ok(Math.abs(game.elapsed - 0.2) < 1e-9);
+    assert.ok(Math.abs(game.balls[0].x - 500) < 1e-9);
+});
+
+test('uses small physics steps so a fast ball still hits a paddle', () => {
+    const game = createGame();
+    startGame(game);
+    const ball = game.balls[0];
+    game.serveIn = 0;
+    ball.x = 80;
+    ball.y = game.paddles[0].y + game.paddles[0].h / 2;
+    ball.vx = -720;
+    ball.vy = 0;
+
+    update(game, 0.1);
+
+    assert.ok(ball.vx > 0, 'ball should bounce instead of crossing the paddle');
+    assert.deepEqual(game.score, [0, 0]);
+});
+
+test('a rematch clears stale input and winner state', () => {
+    const game = createGame();
+    startGame(game);
+    setInput(game, 0, { down: true, targetY: 500 });
+    for (let score = 0; score < 7; score += 1) point(game, 0);
+
+    startGame(game);
+
+    assert.equal(game.winner, undefined);
+    assert.deepEqual(game.inputs, [
+        { up: false, down: false, targetY: null },
+        { up: false, down: false, targetY: null }
+    ]);
+});

--- a/tests/rooms.test.js
+++ b/tests/rooms.test.js
@@ -43,3 +43,38 @@ test('requires a valid passcode when creating private rooms', () => {
     assert.throws(() => rooms.create(socket()), /4.*32 characters/);
     assert.throws(() => rooms.create(socket(), { passcode: 'abc' }), /4.*32 characters/);
 });
+
+test('an old socket closing cannot disconnect a resumed player', () => {
+    const rooms = new RoomManager();
+    const oldSocket = socket();
+    const host = rooms.create(oldSocket, { visibility: 'public' });
+    const newSocket = socket();
+
+    rooms.resume(host.room.code, host.player.token, newSocket);
+
+    assert.equal(rooms.disconnect(host.room, host.player, oldSocket), false);
+    assert.equal(host.player.connected, true);
+    assert.equal(host.player.socket, newSocket);
+});
+
+test('ready messages cannot reset a match that is already running', () => {
+    const rooms = new RoomManager();
+    const host = rooms.create(socket(), { visibility: 'public' });
+    const guest = rooms.join(host.room.code, socket());
+    rooms.ready(host.room, host.player);
+    rooms.ready(host.room, guest.player);
+    host.room.game.score[0] = 3;
+
+    assert.throws(() => rooms.ready(host.room, host.player), /already in progress/i);
+    assert.deepEqual(host.room.game.score, [3, 0]);
+});
+
+test('one player becoming ready does not mark the opponent ready', () => {
+    const rooms = new RoomManager();
+    const host = rooms.create(socket(), { visibility: 'public' });
+    const guest = rooms.join(host.room.code, socket());
+
+    assert.equal(rooms.ready(host.room, host.player), false);
+    assert.deepEqual(host.room.players.map(player => player.ready), [true, false]);
+    assert.equal(rooms.ready(host.room, guest.player), true);
+});


### PR DESCRIPTION
### Motivation
- Prevent stale socket closures from affecting resumed online sessions and make ready/rematch behavior clearer to players.
- Avoid physics tunnelling and preserve elapsed game time during event-loop stalls in the server-side pong simulation.
- Improve Minesweeper performance by avoiding repeated re-renders and win checks during large flood-fill reveals.

### Description
- Pong client: introduce `applyReadyStatus` and update message handling to display per-player ready state, adjust `readyOnlineButton` states/text, and refine UI messages for room status and match start.
- Server websocket and rooms: prevent an older socket from acting for a replaced session, include `ready` arrays in `room-status` broadcasts, pass the socket into `disconnect` to ignore stale closes, and only broadcast `peer-left` when a real disconnect occurred; `ready` now throws if a match is already running.
- Game simulation: refactor `update` into `updateStep` and a new `update` that chops long `dt` into small steps (capped) to preserve elapsed time while preventing fast balls from tunnelling through paddles, and clear `winner` and stale `inputs` on `startGame`.
- Minesweeper: replace recursive `reveal` calls with an iterative flood-fill queue to reveal empty regions in one pass and avoid expensive repeated board rebuilds and premature win checks.
- Tests: add unit tests covering update stepping behavior, physics collision with small steps, rematch state reset, resumed-socket resilience, and ready-state semantics.

### Testing
- Ran the test suite with `npm test`; all tests succeeded.
- Added and ran new tests in `tests/game.test.js` covering event-loop stalls, small physics steps, and rematch state clearing, which passed.
- Added and ran new tests in `tests/rooms.test.js` covering resumed-socket close handling and ready behavior, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a78ca7bd88320a65f231e91c5a14c)