### PR TITLE
Fix Sudoku share button hover shift

### DIFF
--- a/Sudoku/styles.css
+++ b/Sudoku/styles.css
@@ -86,6 +86,7 @@ kbd { padding: 1px 4px; border: 1px solid var(--line); border-radius: 3px; backg
 .modal-card h2 { font-size: 38px; }
 .modal-card p:not(.eyebrow) { margin: 15px 0 27px; color: var(--muted); }
 .finish-actions { display:grid; gap:10px; }
+#share-result:hover { transform:none; }
 .secondary-button { width:100%; padding:14px 18px; border:1px solid var(--line); border-radius:7px; color:var(--ink); background:transparent; font-weight:700; cursor:pointer; }
 .secondary-button:hover { background:rgba(32,53,47,.06); }
 .celebration { margin-bottom: 16px; color: var(--accent); font-size: 48px; }


### PR DESCRIPTION
## Summary

- keep the Sudoku result Share button stationary when hovered
- preserve the existing hover color and shadow feedback

## Root cause

The Share button reused the global `.primary-button:hover` transform. In the result modal, that transform displaced the button instead of keeping it aligned with the modal action area.

## Impact

The Share button no longer shifts out of position when the pointer moves over it.

## Validation

- `npm.cmd run check`
- `npm.cmd test` (21 tests passed)
- `git diff --check`