### PR TITLE
Add in-app preview before sharing generated result images

### DIFF
--- a/arcade.css
+++ b/arcade.css
@@ -11,4 +11,20 @@
 .arcade-auth-actions button { flex: 1; padding: 11px; color: #10271f; background: #83e6c3; border: 0; border-radius: 10px; font: 700 14px system-ui; cursor: pointer; }
 .arcade-auth-actions .secondary { color: white; background: rgba(255,255,255,.08); }
 .arcade-auth-message { min-height: 1.5em; color: #ffb3a7; }
+.result-share-dialog { width: min(680px, calc(100% - 28px)); overflow: hidden; }
+.result-share-content { display: grid; gap: 16px; padding: 22px; font: 15px/1.45 system-ui, sans-serif; }
+.result-share-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; }
+.result-share-heading h2, .result-share-content p { margin: 0; }
+.result-share-heading h2 { font-size: clamp(21px, 4vw, 28px); }
+.result-share-eyebrow { margin-bottom: 3px !important; color: #83e6c3; font-size: 12px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.result-share-close { width: 36px; height: 36px; padding: 0; color: #dbe3ee; background: rgba(255,255,255,.08); border: 0; border-radius: 50%; font: 25px/1 system-ui; cursor: pointer; }
+.result-share-image-wrap { overflow: hidden; background: #0d1420; border: 1px solid rgba(255,255,255,.14); border-radius: 14px; }
+.result-share-image-wrap img { display: block; width: 100%; height: auto; aspect-ratio: 40 / 21; object-fit: contain; }
+.result-share-caption { color: #f7f8fc; }
+.result-share-link { overflow: hidden; color: #9fabbc; font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.result-share-actions { display: flex; justify-content: flex-end; gap: 10px; }
+.result-share-actions button { min-width: 110px; padding: 11px 16px; border: 0; border-radius: 10px; font: 700 14px system-ui; cursor: pointer; }
+.result-share-cancel { color: #f7f8fc; background: rgba(255,255,255,.09); }
+.result-share-confirm { color: #10271f; background: #83e6c3; }
 @media (max-width: 650px) { .arcade-account { top: auto; right: 10px; bottom: 10px; } }
+@media (max-width: 480px) { .result-share-content { padding: 17px; } .result-share-actions button { flex: 1; } }

--- a/arcade.js
+++ b/arcade.js
@@ -11,7 +11,7 @@
     const account = document.createElement('nav');
     account.className = 'arcade-account'; account.setAttribute('aria-label', 'Arcade account');
     const dialog = document.createElement('dialog'); dialog.className = 'arcade-dialog';
-    dialog.innerHTML = `<form class="arcade-auth" method="dialog"><h2>Arcade account</h2><p>Use one gamertag to save play history and scores across every game.</p><label>Gamertag<input name="gamertag" minlength="3" maxlength="24" pattern="[A-Za-z0-9_-]+" autocomplete="username" required></label><label>Passcode<input name="passcode" type="password" minlength="4" maxlength="128" autocomplete="current-password" required></label><p class="arcade-auth-message" role="status"></p><div class="arcade-auth-actions"><button value="login">Sign in</button><button value="register" class="secondary">Create account</button><button value="cancel" class="secondary">Cancel</button></div></form>`;
+    dialog.innerHTML = `<form class="arcade-auth" method="dialog"><h2>Arcade account</h2><p>Use one gamertag to save play history and scores across every game.</p><label>Gamertag<input name="gamertag" minlength="3" maxlength="24" pattern="[A-Za-z0-9_-]+" autocomplete="username" required></label><label>Passcode<input name="passcode" type="password" minlength="4" maxlength="128" autocomplete="current-password" required></label><p class="arcade-auth-message" role="status"></p><div class="arcade-auth-actions"><button value="login">Sign in</button><button value="register" class="secondary">Create account</button><button value="cancel" class="secondary" formnovalidate>Cancel</button></div></form>`;
     document.body.append(account, dialog);
     const render = () => {
         account.replaceChildren();

--- a/scripts/share-result.js
+++ b/scripts/share-result.js
@@ -65,8 +65,50 @@
         return card;
     }
     const toBlob = element => new Promise((resolve, reject) => element.toBlob(blob => blob ? resolve(blob) : reject(new Error('Could not create image.')), 'image/png'));
+    function preview({ blob, title, text, url }) {
+        if (typeof HTMLDialogElement === 'undefined') return Promise.resolve(true);
+        const objectUrl = URL.createObjectURL(blob);
+        const dialog = document.createElement('dialog');
+        dialog.className = 'arcade-dialog result-share-dialog';
+        dialog.setAttribute('aria-labelledby', 'result-share-title');
+        dialog.innerHTML = `
+            <div class="result-share-content">
+                <div class="result-share-heading">
+                    <div>
+                        <p class="result-share-eyebrow">Ready to share</p>
+                        <h2 id="result-share-title"></h2>
+                    </div>
+                    <button class="result-share-close" type="button" aria-label="Close preview">×</button>
+                </div>
+                <div class="result-share-image-wrap"><img alt="Preview of the generated result image"></div>
+                <p class="result-share-caption"></p>
+                <p class="result-share-link"></p>
+                <div class="result-share-actions">
+                    <button class="result-share-cancel" type="button">Cancel</button>
+                    <button class="result-share-confirm" type="button">Share photo</button>
+                </div>
+            </div>`;
+        dialog.querySelector('h2').textContent = title;
+        dialog.querySelector('img').src = objectUrl;
+        dialog.querySelector('.result-share-caption').textContent = text;
+        dialog.querySelector('.result-share-link').textContent = new URL(url, location.href).host;
+        document.body.append(dialog);
+        return new Promise(resolve => {
+            let confirmed = false;
+            const finish = value => { confirmed = value; dialog.close(); };
+            dialog.querySelector('.result-share-confirm').addEventListener('click', () => finish(true));
+            dialog.querySelector('.result-share-cancel').addEventListener('click', () => finish(false));
+            dialog.querySelector('.result-share-close').addEventListener('click', () => finish(false));
+            dialog.addEventListener('cancel', () => { confirmed = false; });
+            dialog.addEventListener('close', () => {
+                URL.revokeObjectURL(objectUrl); dialog.remove(); resolve(confirmed);
+            }, { once: true });
+            dialog.showModal();
+        });
+    }
     async function share({ image, filename, title, text, url = location.href }) {
         const blob = await toBlob(image), file = new File([blob], filename, { type: 'image/png' });
+        if (!await preview({ blob, title, text, url })) throw new DOMException('Share cancelled', 'AbortError');
         if (navigator.share && navigator.canShare?.({ files: [file] })) { await navigator.share({ title, text, url, files: [file] }); return 'shared'; }
         const link = document.createElement('a'); link.href = URL.createObjectURL(blob); link.download = filename; link.click(); setTimeout(() => URL.revokeObjectURL(link.href), 1000);
         try { await navigator.clipboard.writeText(`${text}\n${url}`); return 'downloaded-copy'; } catch { return 'downloaded'; }


### PR DESCRIPTION
### Motivation

- Improve the sharing UX by showing a full preview of the generated result image along with its title, caption, and destination host before opening the system share sheet.

### Description

- Add a `preview()` helper in `scripts/share-result.js` that creates an accessible `<dialog>` showing the image preview, title, caption, host, and confirm/cancel controls and resolves with the user's confirmation.
- If the user cancels the preview the share flow is aborted with an `AbortError`, and after confirmation the existing native file sharing (`navigator.share`) and download/copy fallback are preserved.
- Add responsive styling in `arcade.css` for the preview dialog, image container, caption, link, and action buttons to match the app design and mobile layouts.
- Ensure temporary object URLs are revoked and dialog elements removed on close to avoid resource leaks.

### Testing

- Ran `git diff --check` with no issues reported.
- Ran `npm test` and all tests passed (21 tests).
- Ran `npm run check` (static checks) with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ab69d4c4483208bd14182d8d9c200)