### PR TITLE
Show board image preview in the iOS share sheet

### DIFF
--- a/scripts/share-result.js
+++ b/scripts/share-result.js
@@ -109,7 +109,14 @@
     async function share({ image, filename, title, text, url = location.href }) {
         const blob = await toBlob(image), file = new File([blob], filename, { type: 'image/png' });
         if (!await preview({ blob, title, text, url })) throw new DOMException('Share cancelled', 'AbortError');
-        if (navigator.share && navigator.canShare?.({ files: [file] })) { await navigator.share({ title, text, url, files: [file] }); return 'shared'; }
+        const photo = { files: [file] };
+        // A URL makes iOS treat this as a collection of separate items ("1 Link and
+        // 1 Image"), so its share sheet uses a generic document icon. Sharing the
+        // generated PNG as the sole item gives the sheet an actual image preview.
+        const appleMobile = /iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (/Mac/.test(navigator.platform) && navigator.maxTouchPoints > 1);
+        const shareData = appleMobile ? photo : { title, text, url, ...photo };
+        if (navigator.share && navigator.canShare?.(photo)) { await navigator.share(shareData); return 'shared'; }
         const link = document.createElement('a'); link.href = URL.createObjectURL(blob); link.download = filename; link.click(); setTimeout(() => URL.revokeObjectURL(link.href), 1000);
         try { await navigator.clipboard.writeText(`${text}\n${url}`); return 'downloaded-copy'; } catch { return 'downloaded'; }
     }


### PR DESCRIPTION
### Motivation
- On iOS/iPadOS the native share sheet was showing a generic document icon instead of a thumbnail for generated board images because the share payload included a URL alongside the image.
- The change aims to make the share sheet display the actual generated PNG preview while preserving the richer share payload on non-Apple platforms.

### Description
- Updated `scripts/share-result.js` `share` function to create a `File` from the generated canvas PNG and wrap it in `photo = { files: [file] }` for native sharing. 
- Detect Apple mobile/tablet devices via `navigator.userAgent` and `navigator.platform`/`navigator.maxTouchPoints` and send only `photo` to `navigator.share` on those devices so the share sheet shows the image thumbnail. 
- Preserve `title`, `text`, and `url` in the `share` payload for non-Apple platforms by merging them with the `files` array when appropriate. 
- Kept the existing preview dialog and the download + clipboard-copy fallback when native file sharing is unavailable.

### Testing
- Ran `npm test` and all 21 unit/integration tests passed. 
- Ran `npm run check` (static checks / `node --check` across scripts) which completed without errors. 
- Ran `git diff --check` to ensure no whitespace or diff issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7abc0733688320a6cf63cda743e39e)