### PR TITLE
Make arcade game cards equal size

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
         .game-grid {
             display: grid;
             grid-template-columns: repeat(2, minmax(0, 1fr));
+            grid-auto-rows: 1fr;
             gap: 18px;
         }
 
@@ -163,8 +164,6 @@
             filter: blur(8px);
         }
 
-        .card-featured { grid-column: 1 / -1; min-height: 330px; }
-        .card-featured .card-copy { max-width: 610px; }
         .card:nth-child(2) { --glow: var(--blue-glow); }
         .card:nth-child(3) { --glow: var(--purple-glow); }
 
@@ -230,7 +229,6 @@
             .header-note { display: none; }
             .intro { margin-bottom: 42px; }
             .game-grid { grid-template-columns: 1fr; }
-            .card-featured { grid-column: auto; }
             .card { min-height: 0; border-radius: 22px; }
             .card-top { margin-bottom: 38px; }
             .actions { flex-direction: column; }
@@ -255,7 +253,7 @@
         </section>
 
         <section class="game-grid" aria-label="Games">
-            <article class="card card-featured">
+            <article class="card">
                 <div class="card-top">
                     <span class="game-icon" aria-hidden="true">⌗</span>
                     <span class="badge">New edition available</span>

--- a/tests/homepage-theme.test.js
+++ b/tests/homepage-theme.test.js
@@ -18,3 +18,8 @@ test('homepage surfaces use theme palette variables', () => {
     assert.match(homepage, /background:\s*var\(--panel\);/);
     assert.match(homepage, /box-shadow:\s*0 24px 70px var\(--card-shadow\);/);
 });
+
+test('homepage gives every game card the same grid footprint', () => {
+    assert.match(homepage, /\.game-grid\s*{[^}]*grid-template-columns:\s*repeat\(2, minmax\(0, 1fr\)\);[^}]*grid-auto-rows:\s*1fr;/s);
+    assert.doesNotMatch(homepage, /card-featured/);
+});


### PR DESCRIPTION
### Motivation

- The homepage treated Sudoku as a featured card which made it larger than other games, so the grid should enforce equal card heights to keep the layout consistent.

### Description

- Add `grid-auto-rows: 1fr` to the `.game-grid` rule in `index.html` so all grid tracks share equal height. 
- Remove the `.card-featured` styling from the stylesheet in `index.html` so no card is given a larger footprint. 
- Remove the `card-featured` class from the Sudoku `<article>` element in `index.html` so Sudoku uses the same card layout as other games. 
- Add a regression test in `tests/homepage-theme.test.js` that asserts the presence of `grid-auto-rows: 1fr` in `.game-grid` and the absence of `card-featured` in the homepage HTML.

### Testing

- Ran `npm test` and all tests passed (36 tests). 
- Ran `npm run check` and it completed without errors. 
- Ran `git diff --check` and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c1b803d1c8320a7361e1cbba782cf)