### PR TITLE
Respect iPhone safe areas across arcade pages

### DIFF
--- a/Minesweeper/classic/index.html
+++ b/Minesweeper/classic/index.html
@@ -3,6 +3,7 @@
 <html>
     <head>
         <title>Minesweeper!</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         <script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/tile.js" type="text/javascript"></script>
@@ -10,6 +11,7 @@
         <link rel="icon" href="../../favicon.ico" sizes="any">
         <link rel="apple-touch-icon" href="../../apple-touch-icon.png" sizes="180x180">
         <link rel="manifest" href="../../manifest.webmanifest">
+        <link rel="stylesheet" href="../../arcade.css">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
         <meta name="apple-mobile-web-app-title" content="JS Arcade">

--- a/Sudoku/classic/index.html
+++ b/Sudoku/classic/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <title>Sudoku Classic</title>
     <link rel="icon" href="../../icon.svg" type="image/svg+xml">
     <link rel="icon" href="../../favicon.ico" sizes="any">
     <link rel="apple-touch-icon" href="../../apple-touch-icon.png" sizes="180x180">
     <link rel="manifest" href="../../manifest.webmanifest">
+    <link rel="stylesheet" href="../../arcade.css">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="JS Arcade">

--- a/arcade.css
+++ b/arcade.css
@@ -1,6 +1,9 @@
 :root { --arcade-nav-ink:#20352f; --arcade-nav-bg:rgba(255,253,248,.94); --arcade-nav-line:rgba(32,53,47,.18); --arcade-dialog-bg:#fffdf8; --arcade-dialog-muted:#6d7d76; --arcade-dialog-field:#f3eee5; --arcade-dialog-shadow:#20352f33; }
 :root[data-theme="dark"] { --arcade-nav-ink:#f3f7f4; --arcade-nav-bg:rgba(17,27,24,.94); --arcade-nav-line:rgba(255,255,255,.16); --arcade-dialog-bg:#17231f; --arcade-dialog-muted:#aab8b1; --arcade-dialog-field:#0e1714; --arcade-dialog-shadow:#0009; }
-.arcade-account { position: fixed; z-index: 1000; top: 14px; right: 16px; display: flex; align-items: center; gap: 8px; padding: 7px; color: var(--arcade-nav-ink); background: var(--arcade-nav-bg); border: 1px solid var(--arcade-nav-line); border-radius: 14px; box-shadow: 0 10px 30px var(--arcade-dialog-shadow); font: 600 13px/1.2 system-ui, sans-serif; backdrop-filter:blur(12px); }
+/* Keep the first page control below notched and Dynamic Island status bars. A
+   flow spacer preserves each page's own header spacing instead of replacing it. */
+body::before { display:block; height:env(safe-area-inset-top); content:""; }
+.arcade-account { position: fixed; z-index: 1000; top: calc(14px + env(safe-area-inset-top)); right: max(16px, env(safe-area-inset-right)); display: flex; align-items: center; gap: 8px; padding: 7px; color: var(--arcade-nav-ink); background: var(--arcade-nav-bg); border: 1px solid var(--arcade-nav-line); border-radius: 14px; box-shadow: 0 10px 30px var(--arcade-dialog-shadow); font: 600 13px/1.2 system-ui, sans-serif; backdrop-filter:blur(12px); }
 .arcade-account a, .arcade-account button { padding: 8px 11px; color: inherit; background: transparent; border: 0; border-radius: 9px; font: inherit; text-decoration: none; cursor: pointer; }
 .arcade-account button { color: #10271f; background: #83e6c3; }
 .arcade-theme { display:flex; padding:3px; border-radius:9px; background:var(--arcade-dialog-field); }

--- a/pong/classic/index.html
+++ b/pong/classic/index.html
@@ -3,6 +3,7 @@
 <html>
     <head>
         <title>PONG!</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
         <script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/board.js" type="text/javascript"></script>
@@ -11,6 +12,7 @@
         <link rel="icon" href="../../favicon.ico" sizes="any">
         <link rel="apple-touch-icon" href="../../apple-touch-icon.png" sizes="180x180">
         <link rel="manifest" href="../../manifest.webmanifest">
+        <link rel="stylesheet" href="../../arcade.css">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
         <meta name="apple-mobile-web-app-title" content="JS Arcade">

--- a/tests/shared-game-assets.test.js
+++ b/tests/shared-game-assets.test.js
@@ -27,7 +27,29 @@ test('competitive games consume the same shared color palette', () => {
 test('shared arcade UI keeps mobile navigation above the safe area and displays the build version', () => {
     const styles = read('arcade.css');
     const script = read('arcade.js');
+    assert.match(styles, /body::before\s*{[^}]*height:env\(safe-area-inset-top\)/);
+    assert.match(styles, /top:\s*calc\(14px \+ env\(safe-area-inset-top\)\)/);
     assert.match(styles, /bottom:\s*max\(10px, env\(safe-area-inset-bottom\)\)/);
     assert.match(script, /api\/version/);
     assert.match(script, /arcade-build-version/);
+});
+
+test('every arcade page opts into shared iPhone safe-area handling', () => {
+    const pages = [
+        'index.html',
+        'profile.html',
+        'pong/index.html',
+        'pong/classic/index.html',
+        'Sudoku/index.html',
+        'Sudoku/classic/index.html',
+        'Minesweeper/index.html',
+        'Minesweeper/classic/index.html',
+        'tictactoe/index.html'
+    ];
+
+    for (const page of pages) {
+        const html = read(page);
+        assert.match(html, /viewport-fit=cover/, `${page} should expose the iPhone safe area`);
+        assert.match(html, /arcade\.css/, `${page} should load the shared safe-area styles`);
+    }
 });


### PR DESCRIPTION
### Motivation
- Prevent the site header and the fixed account navigation from overlapping Apple device status bars and notches by honoring the iPhone safe-area insets across all pages. 
- Ensure preserved/classic game pages opt into the same shared UI styles so the fix applies consistently to modern and legacy pages. 

### Description
- Add a top-flow spacer `body::before { height: env(safe-area-inset-top); }` and update `.arcade-account` to use `top: calc(14px + env(safe-area-inset-top))` and `right: max(16px, env(safe-area-inset-right))` so fixed controls sit below notches. 
- Opt classic game pages into viewport safe-area support by adding `viewport-fit=cover` and include the shared `arcade.css` on `Minesweeper/classic/index.html`, `Sudoku/classic/index.html`, and `pong/classic/index.html`. 
- Add regression assertions in `tests/shared-game-assets.test.js` to verify the new `body::before` spacer and top calculation are present in `arcade.css`, and to assert each arcade page includes `viewport-fit=cover` and loads `arcade.css`. 
- Minor inline comment in `arcade.css` describing the safe-area spacer intent. 

### Testing
- Ran `npm test` which executed the full test suite and reported all `39` tests passing. 
- Ran `npm run check` which performed static checks and reported success. 
- Ran `git diff --check` as part of validation and confirmed no remaining diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c9b880c8483208490a7b8da305eb6)