### PR TITLE
Harden HTTP and WebSocket request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,10 @@ TRUST_PROXY=true
 ```
 
 `TRUST_PROXY=true` is appropriate when the container is reachable only through
-the trusted NAS reverse proxy; it lets authentication throttling use the first
-forwarded client address. Leave it false if clients can connect directly to the
-container port and supply their own forwarding headers.
+the trusted NAS reverse proxy; it lets authentication throttling use the
+proxy-adjacent forwarded client address and origin checks use the forwarded
+protocol. Leave it false if clients can connect directly to the container port
+and supply their own forwarding headers.
 
 Authentication attempts are throttled by client address and gamertag, and
 passcode hashing runs asynchronously so it does not block game simulation.
@@ -136,8 +137,9 @@ WebSocket** option; otherwise ensure they forward the `Upgrade` and `Connection`
 headers. Invitation links use the browser's current public host and automatically
 choose `wss://` when the page is served over HTTPS.
 
-Optionally restrict accepted browser origins in `.env` with a comma-separated
-allowlist:
+Browser HTTP and WebSocket requests must use the site's own origin by default.
+To permit additional trusted front-end origins, provide a comma-separated
+allowlist in `.env`:
 
 ```dotenv
 ALLOWED_ORIGINS=https://pong.example.com

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "node --watch server/index.js",
     "generate:icons": "node scripts/generate-icons.js",
     "test": "node --test",
-    "check": "node --check server/index.js && node --check server/achievements.js && node --check server/tictactoe-rooms.js && node --check tictactoe/scripts/app.js && node --check server/database.js && node --check server/accounts.js && node --check server/game.js && node --check server/rooms.js && node --check theme-init.js && node --check arcade.js && node --check profile.js && node --check pong/scripts/app.js && node --check Sudoku/scripts/app.js && node --check Minesweeper/scripts/app.js && node --check scripts/generate-icons.js && node --check scripts/game-colors.js && node --check scripts/share-result.js",
+    "check": "node --check server/index.js && node --check server/http-security.js && node --check server/achievements.js && node --check server/tictactoe-rooms.js && node --check tictactoe/scripts/app.js && node --check server/database.js && node --check server/accounts.js && node --check server/game.js && node --check server/rooms.js && node --check theme-init.js && node --check arcade.js && node --check profile.js && node --check pong/scripts/app.js && node --check Sudoku/scripts/app.js && node --check Minesweeper/scripts/app.js && node --check scripts/generate-icons.js && node --check scripts/game-colors.js && node --check scripts/share-result.js",
     "audit": "npm audit --omit=dev"
   },
   "engines": {

--- a/server/http-security.js
+++ b/server/http-security.js
@@ -47,9 +47,9 @@ function requestOrigin(request, trustProxy = false) {
     return host && !/[\s/\\]/.test(host) ? `${protocol}://${host}` : null;
 }
 
-function originAllowed(request, allowedOrigins, trustProxy = false) {
+function originAllowed(request, allowedOrigins, trustProxy = false, requireOrigin = false) {
     const origin = request.headers.origin;
-    if (!origin) return true;
+    if (!origin) return !requireOrigin;
     return origin === requestOrigin(request, trustProxy) || allowedOrigins.includes(origin);
 }
 

--- a/server/http-security.js
+++ b/server/http-security.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const net = require('node:net');
+
+const PRIVATE_TOP_LEVEL = new Set([
+    'compose.yaml',
+    'compose.nas.yaml',
+    'Dockerfile',
+    'package.json',
+    'package-lock.json',
+    'project.json',
+    'project.lock.json'
+]);
+
+function parseCookies(header) {
+    const result = {};
+    for (const part of String(header || '').split(';')) {
+        const separator = part.indexOf('=');
+        if (separator < 1) continue;
+        try {
+            const name = decodeURIComponent(part.slice(0, separator).trim());
+            if (!name || Object.hasOwn(result, name)) continue;
+            result[name] = decodeURIComponent(part.slice(separator + 1).trim());
+        } catch { /* Ignore malformed cookies rather than failing the request. */ }
+    }
+    return result;
+}
+
+function forwardedValue(header) {
+    return String(header || '').split(',').map(value => value.trim()).filter(Boolean).at(-1);
+}
+
+function clientIp(request, trustProxy = false) {
+    if (trustProxy) {
+        const forwarded = forwardedValue(request.headers['x-forwarded-for']);
+        if (forwarded && net.isIP(forwarded)) return forwarded;
+    }
+    return request.socket.remoteAddress || 'unknown';
+}
+
+function requestOrigin(request, trustProxy = false) {
+    const forwardedProtocol = trustProxy ? forwardedValue(request.headers['x-forwarded-proto']) : '';
+    const protocol = forwardedProtocol === 'https' || forwardedProtocol === 'http'
+        ? forwardedProtocol
+        : request.socket.encrypted ? 'https' : 'http';
+    const host = request.headers.host;
+    return host && !/[\s/\\]/.test(host) ? `${protocol}://${host}` : null;
+}
+
+function originAllowed(request, allowedOrigins, trustProxy = false) {
+    const origin = request.headers.origin;
+    if (!origin) return true;
+    return origin === requestOrigin(request, trustProxy) || allowedOrigins.includes(origin);
+}
+
+function isPrivatePath(pathname) {
+    const segments = pathname.split('/').filter(Boolean);
+    if (segments.some(segment => segment.startsWith('.'))) return true;
+    if (['server', 'tests', 'node_modules', 'data'].includes(segments[0])) return true;
+    return segments.length === 1 && PRIVATE_TOP_LEVEL.has(segments[0]);
+}
+
+module.exports = { clientIp, isPrivatePath, originAllowed, parseCookies, requestOrigin };

--- a/server/index.js
+++ b/server/index.js
@@ -68,8 +68,8 @@ async function readJson(request) {
     for await (const chunk of request) { body += chunk; if (body.length > 10000) throw new Error('Request is too large.'); }
     try { return body ? JSON.parse(body) : {}; } catch { throw new Error('Invalid JSON.'); }
 }
-function sameOrigin(request) {
-    return originAllowed(request, allowedOrigins, trustProxy);
+function sameOrigin(request, requireOrigin = false) {
+    return originAllowed(request, allowedOrigins, trustProxy, requireOrigin);
 }
 
 const server = http.createServer(async (request, response) => {
@@ -155,7 +155,7 @@ const websocketServer = new WebSocketServer({ noServer: true, maxPayload: 4096 }
 server.on('upgrade', (request, socket, head) => {
     let pathname;
     try { pathname = new URL(request.url, 'http://localhost').pathname; } catch { pathname = ''; }
-    if (!['/ws', '/ws/tictactoe'].includes(pathname) || !sameOrigin(request)) {
+    if (!['/ws', '/ws/tictactoe'].includes(pathname) || !sameOrigin(request, true)) {
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n'); socket.destroy(); return;
     }
     websocketServer.handleUpgrade(request, socket, head, client => websocketServer.emit('connection', client, request));

--- a/server/index.js
+++ b/server/index.js
@@ -9,6 +9,7 @@ const { TicTacToeRooms } = require('./tictactoe-rooms');
 const { openDatabase } = require('./database');
 const { Accounts } = require('./accounts');
 const { Achievements } = require('./achievements');
+const { clientIp: getClientIp, isPrivatePath, originAllowed, parseCookies } = require('./http-security');
 
 const root = path.resolve(__dirname, '..');
 const port = Number(process.env.PORT) || 8080;
@@ -38,9 +39,7 @@ function json(response, status, body, headers = {}) {
     response.writeHead(status, { 'content-type': 'application/json; charset=utf-8', 'cache-control': 'no-store', ...headers });
     response.end(JSON.stringify(body));
 }
-function cookies(request) {
-    return Object.fromEntries(String(request.headers.cookie || '').split(';').map(part => part.trim().split('=').map(decodeURIComponent)).filter(pair => pair.length === 2));
-}
+function cookies(request) { return parseCookies(request.headers.cookie); }
 function sessionUser(request) { return accounts.userForToken(cookies(request).arcade_session); }
 function sessionCookie(token, expiresAt) { return `arcade_session=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict; Expires=${new Date(expiresAt).toUTCString()}${process.env.COOKIE_SECURE === 'true' ? '; Secure' : ''}`; }
 class RateLimiter {
@@ -62,7 +61,7 @@ const loginLimiter = new RateLimiter(10, 15 * 60 * 1000);
 const loginIpLimiter = new RateLimiter(50, 15 * 60 * 1000);
 const registrationLimiter = new RateLimiter(5, 60 * 60 * 1000);
 const resultLimiter = new RateLimiter(60, 60 * 60 * 1000);
-function clientIp(request) { return trustProxy ? String(request.headers['x-forwarded-for'] || '').split(',')[0].trim() || request.socket.remoteAddress : request.socket.remoteAddress; }
+function clientIp(request) { return getClientIp(request, trustProxy); }
 function throttle(response, retryAfter) { return json(response, 429, { error: 'Too many attempts. Try again later.' }, { 'retry-after': retryAfter }); }
 async function readJson(request) {
     let body = '';
@@ -70,12 +69,17 @@ async function readJson(request) {
     try { return body ? JSON.parse(body) : {}; } catch { throw new Error('Invalid JSON.'); }
 }
 function sameOrigin(request) {
-    const origin = request.headers.origin;
-    return !origin || origin === `${request.headers['x-forwarded-proto'] || 'http'}://${request.headers.host}` || allowedOrigins.includes(origin);
+    return originAllowed(request, allowedOrigins, trustProxy);
 }
 
 const server = http.createServer(async (request, response) => {
-    const pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname);
+    response.setHeader('x-content-type-options', 'nosniff');
+    response.setHeader('referrer-policy', 'strict-origin-when-cross-origin');
+    response.setHeader('x-frame-options', 'DENY');
+    response.setHeader('permissions-policy', 'camera=(), microphone=(), geolocation=()');
+    let pathname;
+    try { pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname); }
+    catch { response.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' }).end('Bad request'); return; }
     if (pathname === '/healthz') {
         response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
         response.end(JSON.stringify({ status: 'ok', rooms: rooms.rooms.size }));
@@ -131,7 +135,7 @@ const server = http.createServer(async (request, response) => {
             return json(response, clientError ? 400 : 500, { error: clientError ? error.message : 'Server error.' });
         }
     }
-    if (/^\/(?:server|tests|node_modules)(?:\/|$)/.test(pathname) || /^\/(?:package(?:-lock)?\.json|compose\.yaml|Dockerfile|project(?:\.lock)?\.json)$/.test(pathname)) {
+    if (isPrivatePath(pathname)) {
         response.writeHead(404).end('Not found');
         return;
     }
@@ -142,15 +146,16 @@ const server = http.createServer(async (request, response) => {
     } catch { /* handled by readFile */ }
     fs.readFile(filePath, (error, content) => {
         if (error) { response.writeHead(error.code === 'ENOENT' ? 404 : 500).end(error.code === 'ENOENT' ? 'Not found' : 'Server error'); return; }
-        response.writeHead(200, { 'content-type': mime[path.extname(filePath)] || 'application/octet-stream', 'x-content-type-options': 'nosniff' });
+        response.writeHead(200, { 'content-type': mime[path.extname(filePath)] || 'application/octet-stream' });
         response.end(content);
     });
 });
 
 const websocketServer = new WebSocketServer({ noServer: true, maxPayload: 4096 });
 server.on('upgrade', (request, socket, head) => {
-    const origin = request.headers.origin;
-    if (!['/ws', '/ws/tictactoe'].includes(new URL(request.url, 'http://localhost').pathname) || (allowedOrigins.length && !allowedOrigins.includes(origin))) {
+    let pathname;
+    try { pathname = new URL(request.url, 'http://localhost').pathname; } catch { pathname = ''; }
+    if (!['/ws', '/ws/tictactoe'].includes(pathname) || !sameOrigin(request)) {
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n'); socket.destroy(); return;
     }
     websocketServer.handleUpgrade(request, socket, head, client => websocketServer.emit('connection', client, request));

--- a/tests/http-security.test.js
+++ b/tests/http-security.test.js
@@ -21,6 +21,12 @@ test('origin checks use direct connection details unless the proxy is trusted', 
     assert.equal(originAllowed(request({ host: 'arcade.test', origin: 'https://approved.test' }), ['https://approved.test']), true);
 });
 
+test('origin checks can require the header for WebSocket handshakes', () => {
+    const withoutOrigin = request({ host: 'arcade.test' });
+    assert.equal(originAllowed(withoutOrigin, [], false), true, 'ordinary non-browser API clients remain supported');
+    assert.equal(originAllowed(withoutOrigin, [], false, true), false, 'WebSocket handshakes must identify their origin');
+});
+
 test('trusted proxy addresses must be valid and use the proxy-adjacent value', () => {
     assert.equal(clientIp(request({ 'x-forwarded-for': '203.0.113.4, 198.51.100.7' }), true), '198.51.100.7');
     assert.equal(clientIp(request({ 'x-forwarded-for': 'not-an-ip' }), true), '127.0.0.1');

--- a/tests/http-security.test.js
+++ b/tests/http-security.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { clientIp, isPrivatePath, originAllowed, parseCookies, requestOrigin } = require('../server/http-security');
+
+function request(headers = {}, encrypted = false) {
+    return { headers, socket: { encrypted, remoteAddress: '127.0.0.1' } };
+}
+
+test('cookie parsing tolerates malformed values and preserves equals signs', () => {
+    assert.deepEqual(parseCookies('session=a%3Db; broken=%E0%A4%A; theme=dark'), { session: 'a=b', theme: 'dark' });
+    assert.deepEqual(parseCookies('arcade_session=first; arcade_session=second'), { arcade_session: 'first' });
+});
+
+test('origin checks use direct connection details unless the proxy is trusted', () => {
+    const spoofed = request({ host: 'arcade.test', origin: 'https://arcade.test', 'x-forwarded-proto': 'https' });
+    assert.equal(requestOrigin(spoofed, false), 'http://arcade.test');
+    assert.equal(originAllowed(spoofed, [], false), false);
+    assert.equal(originAllowed(spoofed, [], true), true);
+    assert.equal(originAllowed(request({ host: 'arcade.test', origin: 'https://approved.test' }), ['https://approved.test']), true);
+});
+
+test('trusted proxy addresses must be valid and use the proxy-adjacent value', () => {
+    assert.equal(clientIp(request({ 'x-forwarded-for': '203.0.113.4, 198.51.100.7' }), true), '198.51.100.7');
+    assert.equal(clientIp(request({ 'x-forwarded-for': 'not-an-ip' }), true), '127.0.0.1');
+});
+
+test('private implementation and configuration paths are not public assets', () => {
+    for (const pathname of ['/.git/config', '/.env', '/server/index.js', '/tests/accounts.test.js', '/data/arcade.sqlite', '/compose.nas.yaml']) {
+        assert.equal(isPrivatePath(pathname), true, pathname);
+    }
+    assert.equal(isPrivatePath('/pong/index.html'), false);
+});


### PR DESCRIPTION
### Motivation
- Improve server-side security around cookie parsing, reverse-proxy headers, origin checks, and static asset exposure to reduce attack surface and spoofing risk.
- Ensure WebSocket upgrades require the site's origin (or an explicit allowlist) and avoid trusting forwarded protocol/IP values unless explicitly configured.
- Add focused regression coverage for newly introduced checks and document reverse-proxy trust semantics.

### Description
- Add `server/http-security.js` providing robust cookie parsing, proxy-aware `clientIp`, safe `requestOrigin`/`originAllowed` logic, and `isPrivatePath` to prevent serving dotfiles, runtime data, server source, tests, and deployment manifests.
- Harden `server/index.js` to use the new helpers, reject malformed request paths, set baseline browser security headers (`X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`), and require same-origin (or allowlisted) WebSocket upgrades.
- Add `tests/http-security.test.js` with unit tests for cookie handling, forwarded-header behavior, IP selection, origin allowlisting, and private-path classification.
- Update `package.json` `check` script to include the new security module and clarify reverse-proxy guidance in `README.md`.

### Testing
- Ran `npm test` and all tests passed (`47` tests, `0` failures). 
- Ran `npm run check` successfully to validate syntax including the new module. 
- Performed live HTTP smoke checks against a running server to verify security headers, that private paths return `404`, and that malformed URL encoding returns `400` without crashing the server. 
- Attempted `npm audit --omit=dev` but the registry audit endpoint returned `403` in this environment, so audit results are unavailable from this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ca9fd00388320bdbd9078b4c9b18e)