### PR TITLE
Expose Battle Tanks mechanics for testing and add integration tests

### DIFF
--- a/battle-tanks/index.html
+++ b/battle-tanks/index.html
@@ -29,6 +29,6 @@
             <p class="instructions"><strong>Keyboard</strong> <kbd>A</kbd>/<kbd>D</kbd> move · <kbd>W</kbd>/<kbd>S</kbd> aim · <kbd>Q</kbd>/<kbd>E</kbd> power · <kbd>Space</kbd> fire.<br><strong>Touch or pointer</strong> Use the controls, or drag the active tank horizontally in its half.<br>Each tank starts with <strong>100 health</strong>. A direct hit deals 50 damage.</p>
         </aside>
     </section>
-</main><script src="../arcade.js"></script><script src="../scripts/game-colors.js"></script><script src="../scripts/share-result.js"></script><script src="scripts/app.js"></script>
+</main><script src="../arcade.js"></script><script src="../scripts/game-colors.js"></script><script src="../scripts/share-result.js"></script><script src="scripts/game.js"></script><script src="scripts/app.js"></script>
 </body>
 </html>

--- a/battle-tanks/scripts/app.js
+++ b/battle-tanks/scripts/app.js
@@ -1,23 +1,8 @@
 (function(root){
 'use strict';
-const WIDTH=960,HEIGHT=540,GROUND=488,GRAVITY=210,TANK_W=58,TANK_H=30,PROJECTILE_R=6,STARTING_HEALTH=100,DAMAGE=50;
-const barrier={x:448,y:266,w:64,h:GROUND-266};
-const clamp=(value,min,max)=>Math.max(min,Math.min(max,value));
-function createInitialState(){return{phase:'setup',activePlayer:0,tanks:[{x:115,y:GROUND-TANK_H,angle:45,power:60,health:STARTING_HEALTH},{x:WIDTH-115-TANK_W,y:GROUND-TANK_H,angle:45,power:60,health:STARTING_HEALTH}],projectile:null,winner:null,shots:0,hits:0,startedAt:Date.now(),resultSubmitted:false,announcement:'Preparing the arena.'};}
-function beginTurn(state,player=state.activePlayer){if(state.phase==='game-over')return false;state.activePlayer=player;state.phase='aiming';state.projectile=null;state.announcement=`Player ${player+1}: adjust your shot.`;return true;}
-function tankBounds(player){return player===0?{min:0,max:barrier.x-TANK_W}:{min:barrier.x+barrier.w,max:WIDTH-TANK_W};}
-function moveTank(state,direction,amount=8){if(state.phase!=='aiming')return false;const tank=state.tanks[state.activePlayer],bounds=tankBounds(state.activePlayer);tank.x=clamp(tank.x+(direction==='forward'?(state.activePlayer? -amount:amount):(state.activePlayer?amount:-amount)),bounds.min,bounds.max);return true;}
-function adjustAim(state,delta){if(state.phase!=='aiming')return false;const tank=state.tanks[state.activePlayer];tank.angle=clamp(tank.angle+delta,10,80);return true;}
-function adjustPower(state,delta){if(state.phase!=='aiming')return false;const tank=state.tanks[state.activePlayer];tank.power=clamp(tank.power+delta,20,100);return true;}
-function fireProjectile(state){if(state.phase!=='aiming')return false;const tank=state.tanks[state.activePlayer],direction=state.activePlayer? -1:1,radians=tank.angle*Math.PI/180,speed=170+tank.power*3.2;state.shots++;state.projectile={x:tank.x+TANK_W/2+direction*32,y:tank.y-7,vx:Math.cos(radians)*speed*direction,vy:-Math.sin(radians)*speed,owner:state.activePlayer};state.phase='projectile-flight';state.announcement=`Player ${state.activePlayer+1} fired.`;return true;}
-function circleRect(x,y,r,rect){return x+r>=rect.x&&x-r<=rect.x+rect.w&&y+r>=rect.y&&y-r<=rect.y+rect.h;}
-function resolveShot(state,hit){state.projectile=null;if(hit&&hit.type==='tank'){state.hits++;const target=state.tanks[hit.index];target.health=Math.max(0,target.health-DAMAGE);if(target.health===0){state.phase='game-over';state.winner=1-hit.index;state.announcement=`Player ${state.winner+1} wins!`;return hit;}}state.activePlayer=1-state.activePlayer;state.phase='aiming';state.announcement=hit?.type==='tank'?`Direct hit! Player ${state.activePlayer+1}'s turn.`:`Shot ended. Player ${state.activePlayer+1}'s turn.`;return hit;}
-function collisionAt(state,x,y){if(circleRect(x,y,PROJECTILE_R,barrier))return{type:'barrier'};for(let i=0;i<state.tanks.length;i++){const t=state.tanks[i];if(circleRect(x,y,PROJECTILE_R,{x:t.x,y:t.y,w:TANK_W,h:TANK_H}))return{type:'tank',index:i};}if(y+PROJECTILE_R>=GROUND)return{type:'terrain'};if(x+PROJECTILE_R<0||x-PROJECTILE_R>WIDTH||y+PROJECTILE_R<0||y-PROJECTILE_R>HEIGHT)return{type:'out-of-bounds'};return null;}
-function stepPhysics(state,dt=1/120){if(state.phase!=='projectile-flight'||!state.projectile)return null;const p=state.projectile,dx=p.vx*dt,dy=p.vy*dt+.5*GRAVITY*dt*dt,steps=Math.max(1,Math.ceil(Math.max(Math.abs(dx),Math.abs(dy))/3));for(let i=1;i<=steps;i++){const f=i/steps,hit=collisionAt(state,p.x+dx*f,p.y+dy*f);if(hit){p.x+=dx*f;p.y+=dy*f;return resolveShot(state,hit);}}p.x+=dx;p.y+=dy;p.vy+=GRAVITY*dt;return null;}
-function resetMatch(state){const fresh=createInitialState();Object.keys(state).forEach(key=>delete state[key]);Object.assign(state,fresh);beginTurn(state,0);return state;}
-const api={WIDTH,HEIGHT,GROUND,GRAVITY,TANK_W,TANK_H,PROJECTILE_R,STARTING_HEALTH,DAMAGE,barrier,createInitialState,beginTurn,tankBounds,moveTank,adjustAim,adjustPower,fireProjectile,collisionAt,stepPhysics,resolveShot,resetMatch};
-if(typeof module!=='undefined'&&module.exports)module.exports=api;root.BattleTanksCore=api;
-if(typeof document==='undefined')return;
+const api=root.BattleTanksCore;
+if(!api)throw new Error('Battle Tanks mechanics failed to load.');
+const {WIDTH,HEIGHT,GROUND,TANK_W,TANK_H,PROJECTILE_R,STARTING_HEALTH,barrier,createInitialState,beginTurn,tankBounds,moveTank,adjustAim,adjustPower,fireProjectile,stepPhysics,resetMatch}=api;
 const canvas=document.querySelector('#game'),ctx=canvas.getContext('2d'),status=document.querySelector('#status'),fire=document.querySelector('#fire'),rematch=document.querySelector('#rematch'),arena=document.querySelector('#arena'),shareButton=document.querySelector('#share-result'),fullscreenButton=document.querySelector('#fullscreen');const state=createInitialState();let last=performance.now(),accumulator=0,dragging=false;
 const tankColors=[window.ArcadeGameColors[3].value,window.ArcadeGameColors[1].value];
 let arenaColors;

--- a/battle-tanks/scripts/game.js
+++ b/battle-tanks/scripts/game.js
@@ -72,13 +72,20 @@
     }
     function stepPhysics(state, dt = 1 / 120) {
         if (state.phase !== 'projectile-flight' || !state.projectile) return null;
-        const projectile = state.projectile, dx = projectile.vx * dt, dy = projectile.vy * dt + 0.5 * GRAVITY * dt * dt;
-        const steps = Math.max(1, Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)) / 3));
-        for (let index = 1; index <= steps; index += 1) {
-            const fraction = index / steps, hit = collisionAt(state, projectile.x + dx * fraction, projectile.y + dy * fraction);
-            if (hit) { projectile.x += dx * fraction; projectile.y += dy * fraction; return resolveShot(state, hit); }
+        if (!Number.isFinite(dt) || dt <= 0) return null;
+        const projectile = state.projectile;
+        // Follow the parabola in short time slices as well as short distance slices.
+        // Sampling only the straight chord between two distant endpoints can miss a
+        // target below the apex when a browser frame is heavily delayed.
+        const durationSteps = Math.ceil(dt / (1 / 120));
+        const distanceSteps = Math.ceil(Math.max(Math.abs(projectile.vx * dt), Math.abs(projectile.vy * dt + 0.5 * GRAVITY * dt * dt)) / 3);
+        const steps = Math.max(1, durationSteps, distanceSteps), step = dt / steps;
+        for (let index = 0; index < steps; index += 1) {
+            const dx = projectile.vx * step, dy = projectile.vy * step + 0.5 * GRAVITY * step * step;
+            const hit = collisionAt(state, projectile.x + dx, projectile.y + dy);
+            projectile.x += dx; projectile.y += dy; projectile.vy += GRAVITY * step;
+            if (hit) return resolveShot(state, hit);
         }
-        projectile.x += dx; projectile.y += dy; projectile.vy += GRAVITY * dt;
         return null;
     }
     function resetMatch(state) { const fresh = createInitialState(); Object.keys(state).forEach(key => delete state[key]); Object.assign(state, fresh); beginTurn(state, 0); return state; }

--- a/battle-tanks/scripts/game.js
+++ b/battle-tanks/scripts/game.js
@@ -1,0 +1,87 @@
+(function (root, factory) {
+    'use strict';
+    const api = factory();
+    if (typeof module !== 'undefined' && module.exports) module.exports = api;
+    root.BattleTanksCore = api;
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const WIDTH = 960, HEIGHT = 540, GROUND = 488, GRAVITY = 210;
+    const TANK_W = 58, TANK_H = 30, PROJECTILE_R = 6;
+    const STARTING_HEALTH = 100, DAMAGE = 50;
+    const barrier = { x: 448, y: 266, w: 64, h: GROUND - 266 };
+    const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+    function createInitialState() {
+        return {
+            phase: 'setup', activePlayer: 0,
+            tanks: [
+                { x: 115, y: GROUND - TANK_H, angle: 45, power: 60, health: STARTING_HEALTH },
+                { x: WIDTH - 115 - TANK_W, y: GROUND - TANK_H, angle: 45, power: 60, health: STARTING_HEALTH }
+            ],
+            projectile: null, winner: null, shots: 0, hits: 0,
+            startedAt: Date.now(), resultSubmitted: false,
+            announcement: 'Preparing the arena.'
+        };
+    }
+    function beginTurn(state, player = state.activePlayer) {
+        if (state.phase === 'game-over') return false;
+        state.activePlayer = player; state.phase = 'aiming'; state.projectile = null;
+        state.announcement = `Player ${player + 1}: adjust your shot.`;
+        return true;
+    }
+    function tankBounds(player) { return player === 0 ? { min: 0, max: barrier.x - TANK_W } : { min: barrier.x + barrier.w, max: WIDTH - TANK_W }; }
+    function moveTank(state, direction, amount = 8) {
+        if (state.phase !== 'aiming') return false;
+        const tank = state.tanks[state.activePlayer], bounds = tankBounds(state.activePlayer);
+        tank.x = clamp(tank.x + (direction === 'forward' ? (state.activePlayer ? -amount : amount) : (state.activePlayer ? amount : -amount)), bounds.min, bounds.max);
+        return true;
+    }
+    function adjustAim(state, delta) { if (state.phase !== 'aiming') return false; const tank = state.tanks[state.activePlayer]; tank.angle = clamp(tank.angle + delta, 10, 80); return true; }
+    function adjustPower(state, delta) { if (state.phase !== 'aiming') return false; const tank = state.tanks[state.activePlayer]; tank.power = clamp(tank.power + delta, 20, 100); return true; }
+    function fireProjectile(state) {
+        if (state.phase !== 'aiming') return false;
+        const tank = state.tanks[state.activePlayer], direction = state.activePlayer ? -1 : 1;
+        const radians = tank.angle * Math.PI / 180, speed = 170 + tank.power * 3.2;
+        state.shots += 1;
+        state.projectile = { x: tank.x + TANK_W / 2 + direction * 32, y: tank.y - 7, vx: Math.cos(radians) * speed * direction, vy: -Math.sin(radians) * speed, owner: state.activePlayer };
+        state.phase = 'projectile-flight'; state.announcement = `Player ${state.activePlayer + 1} fired.`;
+        return true;
+    }
+    function circleRect(x, y, r, rect) { return x + r >= rect.x && x - r <= rect.x + rect.w && y + r >= rect.y && y - r <= rect.y + rect.h; }
+    function resolveShot(state, hit) {
+        state.projectile = null;
+        if (hit && hit.type === 'tank') {
+            state.hits += 1;
+            const target = state.tanks[hit.index]; target.health = Math.max(0, target.health - DAMAGE);
+            if (target.health === 0) { state.phase = 'game-over'; state.winner = 1 - hit.index; state.announcement = `Player ${state.winner + 1} wins!`; return hit; }
+        }
+        state.activePlayer = 1 - state.activePlayer; state.phase = 'aiming';
+        state.announcement = hit?.type === 'tank' ? `Direct hit! Player ${state.activePlayer + 1}'s turn.` : `Shot ended. Player ${state.activePlayer + 1}'s turn.`;
+        return hit;
+    }
+    function collisionAt(state, x, y) {
+        if (circleRect(x, y, PROJECTILE_R, barrier)) return { type: 'barrier' };
+        for (let index = 0; index < state.tanks.length; index += 1) {
+            const tank = state.tanks[index];
+            if (circleRect(x, y, PROJECTILE_R, { x: tank.x, y: tank.y, w: TANK_W, h: TANK_H })) return { type: 'tank', index };
+        }
+        if (y + PROJECTILE_R >= GROUND) return { type: 'terrain' };
+        if (x + PROJECTILE_R < 0 || x - PROJECTILE_R > WIDTH || y + PROJECTILE_R < 0 || y - PROJECTILE_R > HEIGHT) return { type: 'out-of-bounds' };
+        return null;
+    }
+    function stepPhysics(state, dt = 1 / 120) {
+        if (state.phase !== 'projectile-flight' || !state.projectile) return null;
+        const projectile = state.projectile, dx = projectile.vx * dt, dy = projectile.vy * dt + 0.5 * GRAVITY * dt * dt;
+        const steps = Math.max(1, Math.ceil(Math.max(Math.abs(dx), Math.abs(dy)) / 3));
+        for (let index = 1; index <= steps; index += 1) {
+            const fraction = index / steps, hit = collisionAt(state, projectile.x + dx * fraction, projectile.y + dy * fraction);
+            if (hit) { projectile.x += dx * fraction; projectile.y += dy * fraction; return resolveShot(state, hit); }
+        }
+        projectile.x += dx; projectile.y += dy; projectile.vy += GRAVITY * dt;
+        return null;
+    }
+    function resetMatch(state) { const fresh = createInitialState(); Object.keys(state).forEach(key => delete state[key]); Object.assign(state, fresh); beginTurn(state, 0); return state; }
+
+    return { WIDTH, HEIGHT, GROUND, GRAVITY, TANK_W, TANK_H, PROJECTILE_R, STARTING_HEALTH, DAMAGE, barrier, createInitialState, beginTurn, tankBounds, moveTank, adjustAim, adjustPower, fireProjectile, collisionAt, stepPhysics, resolveShot, resetMatch };
+}));

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "node --watch server/index.js",
     "generate:icons": "node scripts/generate-icons.js",
     "test": "node --test",
-    "check": "node --check battle-tanks/scripts/app.js && node --check server/index.js && node --check server/http-security.js && node --check server/achievements.js && node --check server/tictactoe-rooms.js && node --check tictactoe/scripts/app.js && node --check server/database.js && node --check server/accounts.js && node --check server/game.js && node --check server/rooms.js && node --check theme-init.js && node --check arcade.js && node --check profile.js && node --check pong/scripts/app.js && node --check Sudoku/scripts/app.js && node --check Minesweeper/scripts/app.js && node --check scripts/generate-icons.js && node --check scripts/game-colors.js && node --check scripts/share-result.js",
+    "check": "node --check battle-tanks/scripts/game.js && node --check battle-tanks/scripts/app.js && node --check server/index.js && node --check server/http-security.js && node --check server/achievements.js && node --check server/tictactoe-rooms.js && node --check tictactoe/scripts/app.js && node --check server/database.js && node --check server/accounts.js && node --check server/game.js && node --check server/rooms.js && node --check theme-init.js && node --check arcade.js && node --check profile.js && node --check pong/scripts/app.js && node --check Sudoku/scripts/app.js && node --check Minesweeper/scripts/app.js && node --check scripts/generate-icons.js && node --check scripts/game-colors.js && node --check scripts/share-result.js",
     "audit": "npm audit --omit=dev"
   },
   "engines": {

--- a/tests/accounts.test.js
+++ b/tests/accounts.test.js
@@ -74,3 +74,25 @@ test('paginates profile history ten most-recent games at a time', async t => {
     assert.equal(lastPage.recent.length, 3);
     assert.ok(firstPage.recent[0].id > lastPage.recent[0].id);
 });
+
+test('validates Battle Tanks results, derives scores, ranks players, and persists history', async t => {
+    const accounts = fixture(t);
+    const ace = await accounts.create('TankAce', 'passcode');
+    const rival = await accounts.create('TankRival', 'passcode');
+    const victory = { game: 'battletanks', won: true, details: { mode: 'local', winner: 1, turns: 4, shots: 4, hits: 2, seconds: 40, damageTaken: 0 } };
+    const result = accounts.record(ace.id, { ...victory, score: 999999 });
+    assert.equal(result.score, 14460, 'client-provided scores must not be trusted');
+    accounts.record(rival.id, { game: 'battletanks', won: true, details: { mode: 'local', winner: 1, turns: 5, shots: 5, hits: 2, seconds: 20, damageTaken: 50 } });
+    assert.deepEqual(accounts.leaderboard('battletanks').map(row => row.gamertag), ['TankAce', 'TankRival']);
+    const history = accounts.profile(ace.id).recent.find(row => row.game === 'battletanks');
+    assert.deepEqual(history.details, { mode: 'local', winner: 1, turns: 4, shots: 4, hits: 2, accuracy: 50, seconds: 40, damageTaken: 0 });
+
+    const invalid = [
+        { ...victory, details: { ...victory.details, mode: 'online' } },
+        { ...victory, won: false },
+        { ...victory, details: { ...victory.details, turns: 3 } },
+        { ...victory, details: { ...victory.details, hits: 4 } },
+        { ...victory, details: { ...victory.details, damageTaken: 25 } }
+    ];
+    for (const payload of invalid) assert.throws(() => accounts.record(ace.id, payload), /Invalid Battle Tanks/);
+});

--- a/tests/achievements.test.js
+++ b/tests/achievements.test.js
@@ -50,3 +50,19 @@ test('achievement progress is isolated between users', async t => {
     assert.ok(achievements.list(winner.id, 'pong').some(item => item.unlocked));
     assert.ok(achievements.list(newcomer.id, 'pong').every(item => !item.unlocked));
 });
+
+test('Battle Tanks catalog is public and signed-in progress unlocks each badge only once', async t => {
+    const { accounts, achievements } = fixture(t);
+    const anonymous = achievements.list(null, 'battletanks');
+    assert.deepEqual(anonymous.map(item => item.id), ['tanks-first', 'tanks-win', 'tanks-accurate', 'tanks-untouched']);
+    assert.ok(anonymous.every(item => item.progress === 0 && !item.unlocked));
+
+    const user = await accounts.create('TankBadges', 'passcode');
+    const payload = { game: 'battletanks', won: true, details: { mode: 'local', winner: 1, turns: 4, shots: 4, hits: 2, seconds: 50, damageTaken: 0 } };
+    const first = accounts.record(user.id, payload);
+    assert.deepEqual(first.unlocked.map(item => item.id).sort(), anonymous.map(item => item.id).sort());
+    const signedIn = achievements.list(user.id, 'battletanks');
+    assert.ok(signedIn.every(item => item.progress === 1 && item.unlocked));
+    assert.deepEqual(accounts.record(user.id, payload).unlocked, []);
+    assert.ok(achievements.list(user.id, 'battletanks').every(item => item.progress === 1));
+});

--- a/tests/battle-tanks-page.test.js
+++ b/tests/battle-tanks-page.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const read = file => fs.readFileSync(path.join(root, file), 'utf8');
+
+test('homepage links to Battle Tanks and its page loads all shared arcade assets', () => {
+    assert.match(read('index.html'), /href=["']battle-tanks\/index\.html["']/);
+    const page = read('battle-tanks/index.html');
+    for (const asset of ['../arcade.js', '../theme-init.js', '../scripts/game-colors.js', '../scripts/share-result.js']) {
+        assert.ok(page.includes(asset), `Battle Tanks should load ${asset}`);
+    }
+    assert.match(page, /scripts\/game\.js[\s\S]*scripts\/app\.js/, 'mechanics must load before the browser application');
+});

--- a/tests/battle-tanks.test.js
+++ b/tests/battle-tanks.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const game = require('../battle-tanks/scripts/game');
+
+function match() { const state = game.createInitialState(); game.beginTurn(state); return state; }
+function finish(state, limit = 5000, dt = 1 / 120) {
+    let hit = null;
+    for (let index = 0; index < limit && state.phase === 'projectile-flight'; index += 1) hit = game.stepPhysics(state, dt) || hit;
+    return hit;
+}
+
+test('a new match puts player one and player two on opposite sides', () => {
+    const state = match();
+    assert.equal(state.activePlayer, 0); assert.equal(state.phase, 'aiming');
+    assert.ok(state.tanks[0].x + game.TANK_W <= game.barrier.x);
+    assert.ok(state.tanks[1].x >= game.barrier.x + game.barrier.w);
+});
+
+test('movement clamps each tank to its side of the central barrier', () => {
+    const state = match();
+    game.moveTank(state, 'forward', 10000);
+    assert.equal(state.tanks[0].x, game.barrier.x - game.TANK_W);
+    state.activePlayer = 1; game.moveTank(state, 'forward', 10000);
+    assert.equal(state.tanks[1].x, game.barrier.x + game.barrier.w);
+});
+
+test('angle and power controls enforce their documented ranges', () => {
+    const state = match(); game.adjustAim(state, -1000); game.adjustPower(state, -1000);
+    assert.equal(state.tanks[0].angle, 10); assert.equal(state.tanks[0].power, 20);
+    game.adjustAim(state, 1000); game.adjustPower(state, 1000);
+    assert.equal(state.tanks[0].angle, 80); assert.equal(state.tanks[0].power, 100);
+});
+
+test('gravity bends a projectile upward and then downward', () => {
+    const state = match(); game.fireProjectile(state);
+    const initialVelocity = state.projectile.vy, initialY = state.projectile.y;
+    game.stepPhysics(state, 0.25);
+    assert.ok(state.projectile.y < initialY); assert.ok(state.projectile.vy > initialVelocity);
+});
+
+test('a low shot collides with the central barrier', () => {
+    const state = match(); state.tanks[0].angle = 10; state.tanks[0].power = 100; game.fireProjectile(state);
+    assert.equal(finish(state).type, 'barrier');
+});
+
+test('a sufficiently high shot clears the central barrier', () => {
+    const state = match(); state.tanks[0].angle = 45; state.tanks[0].power = 100; game.fireProjectile(state);
+    assert.notEqual(finish(state).type, 'barrier');
+});
+
+test('a direct collision damages only the target tank', () => {
+    const state = match(); state.projectile = { x: 0, y: 0, vx: 0, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
+    game.resolveShot(state, { type: 'tank', index: 1 });
+    assert.deepEqual(state.tanks.map(tank => tank.health), [100, 50]);
+});
+
+test('all player inputs are ignored during projectile flight', () => {
+    const state = match(); game.fireProjectile(state); const tank = { ...state.tanks[0] };
+    assert.equal(game.moveTank(state, 'forward'), false); assert.equal(game.adjustAim(state, 5), false); assert.equal(game.adjustPower(state, 5), false); assert.equal(game.fireProjectile(state), false);
+    assert.deepEqual(state.tanks[0], tank); assert.equal(state.shots, 1);
+});
+
+test('a miss resolves and advances exactly one turn', () => {
+    const state = match(); state.projectile = { x: 10, y: 100, vx: -1000, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
+    assert.equal(finish(state, 10, 1).type, 'out-of-bounds'); assert.equal(state.activePlayer, 1);
+    assert.equal(game.stepPhysics(state, 1), null); assert.equal(state.activePlayer, 1);
+});
+
+test('lethal damage ends the match without advancing the turn', () => {
+    const state = match(); state.tanks[1].health = game.DAMAGE; state.projectile = {}; state.phase = 'projectile-flight';
+    game.resolveShot(state, { type: 'tank', index: 1 });
+    assert.equal(state.phase, 'game-over'); assert.equal(state.winner, 0); assert.equal(state.activePlayer, 0);
+});
+
+test('rematch resets match state and counters', () => {
+    const state = match(), initial = match(); Object.assign(state, { activePlayer: 1, shots: 9, hits: 2, winner: 1, resultSubmitted: true }); state.tanks[0].x = 3; state.tanks[0].health = 0; state.projectile = {}; state.phase = 'game-over';
+    game.resetMatch(state);
+    assert.deepEqual(state.tanks, initial.tanks); assert.equal(state.projectile, null); assert.equal(state.shots, 0); assert.equal(state.hits, 0); assert.equal(state.activePlayer, 0); assert.equal(state.winner, null); assert.equal(state.resultSubmitted, false); assert.equal(state.phase, 'aiming');
+});
+
+test('large elapsed-time updates sweep collisions instead of tunneling', () => {
+    const state = match(); state.projectile = { x: 300, y: 300, vx: 1000, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
+    assert.equal(game.stepPhysics(state, 0.3).type, 'barrier'); assert.equal(state.activePlayer, 1);
+});

--- a/tests/battle-tanks.test.js
+++ b/tests/battle-tanks.test.js
@@ -33,11 +33,15 @@ test('angle and power controls enforce their documented ranges', () => {
     assert.equal(state.tanks[0].angle, 80); assert.equal(state.tanks[0].power, 100);
 });
 
-test('gravity bends a projectile upward and then downward', () => {
-    const state = match(); game.fireProjectile(state);
-    const initialVelocity = state.projectile.vy, initialY = state.projectile.y;
-    game.stepPhysics(state, 0.25);
-    assert.ok(state.projectile.y < initialY); assert.ok(state.projectile.vy > initialVelocity);
+test('gravity bends a projectile through a rising and falling arc', () => {
+    const state = match(); state.tanks[0].angle = 80; state.tanks[0].power = 20; game.fireProjectile(state);
+    const points = [state.projectile.y];
+    for (let index = 0; index < 300 && state.phase === 'projectile-flight'; index += 1) {
+        game.stepPhysics(state); if (state.projectile) points.push(state.projectile.y);
+    }
+    const apex = Math.min(...points), apexIndex = points.indexOf(apex);
+    assert.ok(apexIndex > 0 && apexIndex < points.length - 1, 'the apex should occur between launch and landing');
+    assert.ok(points[apexIndex - 1] > apex && points[apexIndex + 1] > apex);
 });
 
 test('a low shot collides with the central barrier', () => {
@@ -47,12 +51,20 @@ test('a low shot collides with the central barrier', () => {
 
 test('a sufficiently high shot clears the central barrier', () => {
     const state = match(); state.tanks[0].angle = 45; state.tanks[0].power = 100; game.fireProjectile(state);
-    assert.notEqual(finish(state).type, 'barrier');
+    let crossedAboveBarrier = false;
+    while (state.phase === 'projectile-flight') {
+        game.stepPhysics(state);
+        if (state.projectile && state.projectile.x >= game.barrier.x && state.projectile.x <= game.barrier.x + game.barrier.w) {
+            crossedAboveBarrier ||= state.projectile.y + game.PROJECTILE_R < game.barrier.y;
+        }
+    }
+    assert.equal(crossedAboveBarrier, true);
 });
 
 test('a direct collision damages only the target tank', () => {
-    const state = match(); state.projectile = { x: 0, y: 0, vx: 0, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
-    game.resolveShot(state, { type: 'tank', index: 1 });
+    const state = match(), target = state.tanks[1];
+    state.projectile = { x: target.x - 20, y: target.y + game.TANK_H / 2, vx: 200, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
+    assert.deepEqual(game.stepPhysics(state, 0.2), { type: 'tank', index: 1 });
     assert.deepEqual(state.tanks.map(tank => tank.health), [100, 50]);
 });
 
@@ -83,4 +95,10 @@ test('rematch resets match state and counters', () => {
 test('large elapsed-time updates sweep collisions instead of tunneling', () => {
     const state = match(); state.projectile = { x: 300, y: 300, vx: 1000, vy: 0, owner: 0 }; state.phase = 'projectile-flight';
     assert.equal(game.stepPhysics(state, 0.3).type, 'barrier'); assert.equal(state.activePlayer, 1);
+});
+
+test('invalid elapsed-time updates leave a projectile unchanged', () => {
+    const state = match(); game.fireProjectile(state); const projectile = { ...state.projectile };
+    assert.equal(game.stepPhysics(state, Number.NaN), null); assert.deepEqual(state.projectile, projectile);
+    assert.equal(game.stepPhysics(state, -1), null); assert.deepEqual(state.projectile, projectile);
 });

--- a/tests/shared-game-assets.test.js
+++ b/tests/shared-game-assets.test.js
@@ -11,6 +11,7 @@ const read = file => fs.readFileSync(path.join(root, file), 'utf8');
 test('competitive games consume shared styles without cross-game imports', () => {
     assert.match(read('pong/styles.css'), /styles\/game\.css/);
     assert.match(read('tictactoe/styles.css'), /styles\/game\.css/);
+    assert.match(read('battle-tanks/styles.css'), /styles\/game\.css/);
     assert.doesNotMatch(read('tictactoe/styles.css'), /pong/i);
     assert.doesNotMatch(read('tictactoe/index.html'), /(?:src|href)=["'][^"']*pong/i);
 });


### PR DESCRIPTION
### Motivation
- Make Battle Tanks’ pure state and physics testable in Node without adding a build step by extracting mechanics into a small, consumable module. 
- Ensure the browser application continues to use the same mechanics at runtime and that UI/asset integration is validated. 
- Add comprehensive server- and client-side tests to verify result validation, achievements, leaderboard ordering, and page-level asset requirements.

### Description
- Add a UMD/CommonJS mechanics module at `battle-tanks/scripts/game.js` that exports initial state, movement, aim/power constraints, projectile physics with swept collision, damage resolution, turn handling, and rematch reset. 
- Update the browser app to require the exported `BattleTanksCore` API (`battle-tanks/scripts/app.js` now consumes the module) and load `scripts/game.js` before `scripts/app.js` in `battle-tanks/index.html`. 
- Add Node-driven unit tests in `tests/battle-tanks.test.js` covering initialization, movement clamping, input limits, gravity arc, barrier collision and clearance, direct hits and damage, input locking during flight, turn advancement, lethal-win behavior, rematch resets, and large-step collision safety. 
- Add a page-integration test `tests/battle-tanks-page.test.js` and extend `tests/shared-game-assets.test.js`, `tests/accounts.test.js`, and `tests/achievements.test.js` to include Battle Tanks for shared-assets assertions, server-side result validation/score derivation/leaderboard ordering/history persistence, and achievement visibility/unlock behavior.

### Testing
- Ran the full automated suite with `npm test`, and all tests passed (69/69). 
- Ran the static checks with `npm run check` (`node --check` across updated files) and it completed successfully. 
- Verified the new mechanics module by exercising `stepPhysics` in Node-based smoke runs and by running the integration tests that assert physics and result-validation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7cef318fe48320acc766a181f7f1ee)