### PR TITLE
docs: Add architecture overview and ADRs with mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ history, profiles, and leaderboards. No browser build step is required.
 
 See the diagram-first [architecture overview](docs/architecture.md) for the game
 topology and subsystem flows. Architectural decisions are indexed in
-[the ADR directory](docs/adr/README.md).
+[the ADR directory](docs/adr/README.md), with a dedicated guide to
+[online rendering smoothing and prediction](docs/online-rendering.md).
 
 ## Games
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A small collection of browser games and coding exercises, built for fun and
 learning. The modern games share optional arcade accounts, persistent play
 history, profiles, and leaderboards. No browser build step is required.
 
+## Documentation
+
+See the diagram-first [architecture overview](docs/architecture.md) for the game
+topology and subsystem flows. Architectural decisions are indexed in
+[the ADR directory](docs/adr/README.md).
+
 ## Games
 
 | Game | About | Play |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Architecture documentation
+
+Start with the [architecture map](architecture.md). Decisions are recorded in
+[`adr/`](adr/README.md).
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Architecture documentation
 
 Start with the [architecture map](architecture.md). Decisions are recorded in
-[`adr/`](adr/README.md).
-
+[`adr/`](adr/README.md). Online animation details are covered in
+[rendering smoothing and prediction](online-rendering.md).

--- a/docs/adr/0001-build-free-monolith.md
+++ b/docs/adr/0001-build-free-monolith.md
@@ -1,0 +1,17 @@
+# ADR 0001: Build-free clients and one Node service
+
+**Status:** Accepted
+
+**Decision:** Ship plain HTML/CSS/JavaScript and run static serving, REST, and
+WebSockets in one dependency-light Node process.
+
+```mermaid
+flowchart LR
+  Browser -->|no bundle| Node[Node HTTP + WebSocket]
+  Node --> SQLite
+```
+
+**Consequences:** Static previews remain useful and deployment is small; browser
+globals and a central server router replace module bundling and framework
+boundaries, so larger changes need disciplined tests.
+

--- a/docs/adr/0002-sqlite-and-migrations.md
+++ b/docs/adr/0002-sqlite-and-migrations.md
@@ -1,0 +1,17 @@
+# ADR 0002: SQLite with ordered migrations
+
+**Status:** Accepted
+
+**Decision:** Persist accounts, sessions, results, and achievement progress in a
+single SQLite file on a mounted volume. Apply immutable, filename-ordered SQL
+migrations transactionally at startup.
+
+```mermaid
+flowchart LR
+  Startup --> Scan[scan server/migrations/*.sql] --> Apply[apply missing in transaction] --> Ledger[(schema_migrations)]
+  API --> DB[(arcade.sqlite on persistent volume)]
+```
+
+**Consequences:** Backup and NAS operation are simple and no database service is
+needed; the single-node design is not intended for horizontally scaled writers.
+

--- a/docs/adr/0003-results-and-achievements.md
+++ b/docs/adr/0003-results-and-achievements.md
@@ -1,0 +1,18 @@
+# ADR 0003: Server-derived scores and catalog-driven achievements
+
+**Status:** Accepted
+
+**Decision:** Accept bounded game facts rather than arbitrary scores. Derive
+scores centrally, then evaluate an in-code achievement catalog in the same
+result flow. The authoritative Battle Tanks room writes online results directly.
+
+```mermaid
+flowchart LR
+  Facts[validated result facts] --> Score[game scoring rule] --> Result[(game_results)]
+  Facts --> Rules[achievement catalog] --> Progress[(achievement_progress)]
+```
+
+**Consequences:** Leaderboards use comparable values and rules are testable;
+client-reported results still require plausibility validation and catalog changes
+are deployments rather than data administration.
+

--- a/docs/adr/0004-authoritative-rooms.md
+++ b/docs/adr/0004-authoritative-rooms.md
@@ -1,0 +1,20 @@
+# ADR 0004: Authoritative, ephemeral online rooms
+
+**Status:** Accepted
+
+**Decision:** Keep rooms in process. Clients send intent; room managers validate
+lifecycle and game commands, while servers own online state (including real-time
+Pong and Battle Tanks simulation). Expire abandoned rooms and allow short token-
+based reconnection.
+
+```mermaid
+flowchart LR
+  Client -->|intent| Room[room manager] --> Engine[authoritative state]
+  Engine -->|snapshot| Client
+  Room -->|timeout/restart| Gone[room removed]
+```
+
+**Consequences:** Players converge on one state without room persistence or
+cleanup jobs; matches do not survive process restart and one process owns every
+active room.
+

--- a/docs/adr/0005-session-boundaries.md
+++ b/docs/adr/0005-session-boundaries.md
@@ -1,0 +1,19 @@
+# ADR 0005: Separate opaque account and room sessions
+
+**Status:** Accepted
+
+**Decision:** Store only hashed random account-session tokens and deliver the raw
+token in an HttpOnly cookie. Give each online-room player a separate opaque
+resume token held in browser session storage.
+
+```mermaid
+flowchart TB
+  Cookie[HttpOnly account cookie] --> Account[profile + persistence identity]
+  SessionStore[sessionStorage room token] --> Room[ephemeral player identity]
+  Account -. optional gamertag/user id .-> Room
+```
+
+**Consequences:** Room play does not require an account and scripts cannot read
+account credentials; room tokens remain script-visible and are intentionally
+short-lived with the room.
+

--- a/docs/adr/0006-classic-and-modern.md
+++ b/docs/adr/0006-classic-and-modern.md
@@ -1,0 +1,17 @@
+# ADR 0006: Preserve classic games beside modern games
+
+**Status:** Accepted
+
+**Decision:** Keep original p5.js implementations under each game's `classic/`
+path while modern implementations use the shared arcade shell. Do not retrofit
+classic versions with accounts or online services.
+
+```mermaid
+flowchart LR
+  Game --> Modern[modern: responsive + platform services]
+  Game --> Classic[classic: preserved p5.js experiment]
+```
+
+**Consequences:** Original learning artifacts remain playable and modern work can
+evolve independently; behavior and external p5.js availability differ by version.
+

--- a/docs/adr/0007-same-origin-security.md
+++ b/docs/adr/0007-same-origin-security.md
@@ -1,0 +1,19 @@
+# ADR 0007: Same-origin deployment with layered HTTP security
+
+**Status:** Accepted
+
+**Decision:** Serve pages, API, and WebSockets from one origin behind HTTPS.
+Validate origins (with an explicit allowlist), rate-limit sensitive actions, cap
+payloads, set restrictive headers, hide private paths, and trust proxy headers
+only when configured.
+
+```mermaid
+flowchart LR
+  Browser --> TLS[trusted reverse proxy] --> Guard[origin + limits + headers] --> App
+  Allowlist --> Guard
+```
+
+**Consequences:** Cookies and invitation URLs stay simple and the attack surface
+is constrained; split-origin clients require configuration and proxy trust must
+match the actual network boundary.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,13 @@
+# Architecture decision records
+
+All records describe the current system retrospectively and have status
+**Accepted**.
+
+1. [Build-free browser clients and one Node service](0001-build-free-monolith.md)
+2. [SQLite persistence with ordered migrations](0002-sqlite-and-migrations.md)
+3. [Server-derived scores and catalog-driven achievements](0003-results-and-achievements.md)
+4. [Authoritative, ephemeral online rooms](0004-authoritative-rooms.md)
+5. [Opaque account and room sessions](0005-session-boundaries.md)
+6. [Preserve classic games beside modern games](0006-classic-and-modern.md)
+7. [Same-origin deployment and layered HTTP security](0007-same-origin-security.md)
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ sequenceDiagram
   G->>A: record(game, won, details)
   A->>H: POST /api/results + session cookie
   H->>AC: record(userId, result)
-  AC->>AC: validate fields; derive score
+  AC->>AC: validate fields and derive score
   AC->>DB: insert game_results
   AC->>AH: process(result event)
   AH->>DB: upsert achievement_progress
@@ -192,4 +192,3 @@ checks HTTP/WebSocket origins, caps JSON and WebSocket payloads, and uses a
 heartbeat. Startup applies ordered SQL migrations transactionally. Graceful
 shutdown closes sockets and SQLite. See the [decision index](adr/README.md) for
 the trade-offs behind these boundaries.
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ sequenceDiagram
 |---|---|---|---|
 | Endpoint | `/ws` | `/ws/tictactoe` | `/ws/battle-tanks` |
 | Client command | continuous paddle input | discrete cell move | versioned move/aim/fire command |
-| State delivery | 30 Hz snapshots | after actions | 60 Hz simulation snapshots |
+| State delivery | 30 Hz snapshots | after actions | 60 Hz physics; projectile snapshots capped at 25 Hz (typically about 20 Hz because the 40 ms throttle is sampled by a 60 Hz timer) |
 | Result source | validated client report | validated client report | room manager records authenticated players |
 | Shared lifecycle | public/private five-character rooms, ready, rematch, invitation, resume token, reconnection grace, inactivity expiry, heartbeat |
 
@@ -177,14 +177,19 @@ Battle Tanks also associates the user id for trusted online result recording.
 ```mermaid
 flowchart LR
   Internet --> TLS[Reverse proxy: TLS + WebSocket upgrade]
-  TLS --> C[Single unprivileged container :8080]
-  C --> V[(arcade-data volume)]
-  C --> H[/healthz]
-  subgraph Container
-    C --> Static[Static assets]
-    C --> API[REST API]
-    C --> WS[WebSocket server]
+  subgraph Container[Single unprivileged container]
+    C[Node service on port 8080]
+    Static[Static assets]
+    API[REST API]
+    WS[WebSocket server]
+    Health[healthz endpoint]
+    C --> Static
+    C --> API
+    C --> WS
+    C --> Health
   end
+  TLS --> C
+  C --> V[(arcade-data volume)]
 ```
 
 The server blocks private source/data paths, applies response security headers,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,195 @@
+# Current architecture
+
+The arcade is a build-free browser application plus one Node.js process. The
+process serves the same files used by static hosting, exposes the account API,
+and hosts optional online matches. Classic games are intentionally standalone.
+
+## System topology
+
+```mermaid
+flowchart LR
+  B[Browser] -->|HTTPS: pages, assets, REST| N[Node HTTP server]
+  B <-->|WSS: online matches| N
+  N --> S[(SQLite /app/data/arcade.sqlite)]
+  N --> P[In-memory Pong rooms]
+  N --> T[In-memory Tic-tac-toe rooms]
+  N --> BT[In-memory Battle Tanks rooms]
+  GH[Static host / GitHub Pages] -->|local and solo play only| B
+  RP[HTTPS reverse proxy] --> N
+```
+
+```mermaid
+flowchart TB
+  subgraph Browser
+    Pages[Home, profile, game pages]
+    Arcade[arcade.js: account, theme, results, achievements]
+    Shared[room UI, colors, sharing]
+    Games[game-specific controllers and engines]
+    Store[localStorage: preferences/best times\nsessionStorage: room resume tokens]
+    Pages --> Arcade
+    Pages --> Shared --> Games
+    Arcade --> Games
+    Games --> Store
+  end
+  subgraph Node_process[Node process]
+    HTTP[HTTP routing + static files + security]
+    Accounts[Accounts + result validation/scoring]
+    Achievements[Achievement rules/progress]
+    Rooms[Three room managers]
+    Engines[Pong and Battle Tanks engines]
+    DB[Migration runner]
+    HTTP --> Accounts --> Achievements
+    HTTP --> Rooms --> Engines
+    Accounts --> DB
+    Achievements --> DB
+  end
+  Arcade <-->|JSON REST| HTTP
+  Games <-->|JSON WebSocket| Rooms
+```
+
+## Games and components
+
+| Game | Browser modes / components | Online authority | Platform integration |
+|---|---|---|---|
+| Sudoku | Modern controller with generated boards, notes, hints and solver; separate p5.js classic (`board`, `cell`, `builder`, `solver`, `sketch`) | None | Modern results, scores and achievements |
+| Minesweeper | Modern controller plus tile/grid engine; separate p5.js classic (`sketch`, `tile`) | None | Modern results, browser best times, scores and achievements |
+| Pong | Modern canvas controller + motion prediction; solo, couch duo, online; separate p5.js classic (`board`, `ball`, `sketch`) | Server engine at 60 Hz; snapshots at 30 Hz | Modern results, scores and achievements |
+| Tic-tac-toe | Modern controller, minimax AI, couch duo and online | Room manager validates turns, cells and wins | Results, scores and achievements |
+| Battle Tanks | Shared deterministic engine + canvas controller; local and online | Server validates commands and owns physics, damage, turns and online result recording | Results, scores and achievements |
+
+The coding-challenge folders (`leetcode/`, `codeforces/`, `codewars/`) are
+independent scripts, not arcade games or runtime components.
+
+```mermaid
+flowchart LR
+  Shared[Shared browser shell] --> SU[Sudoku modern]
+  Shared --> MS[Minesweeper modern]
+  Shared --> PO[Pong modern]
+  Shared --> TT[Tic-tac-toe]
+  Shared --> BT[Battle Tanks]
+  P5[p5.js CDN] --> SUC[Sudoku classic]
+  P5 --> MSC[Minesweeper classic]
+  P5 --> POC[Pong classic]
+  PO --> WR[Pong room manager + engine]
+  TT --> TR[Tic-tac-toe room manager]
+  BT --> BR[Battle Tanks room manager + shared engine]
+```
+
+## Accounts, scores and achievements
+
+```mermaid
+sequenceDiagram
+  participant G as Modern game
+  participant A as arcade.js
+  participant H as HTTP API
+  participant AC as Accounts
+  participant AH as Achievements
+  participant DB as SQLite
+  G->>A: record(game, won, details)
+  A->>H: POST /api/results + session cookie
+  H->>AC: record(userId, result)
+  AC->>AC: validate fields; derive score
+  AC->>DB: insert game_results
+  AC->>AH: process(result event)
+  AH->>DB: upsert achievement_progress
+  AC-->>A: score, topScore, unlocked[]
+  A-->>G: toast notifications
+```
+
+Registration/login uses scrypt passcode hashes. A random session token is sent
+only in an HttpOnly, SameSite=Strict cookie; only its SHA-256 hash is stored.
+Profile changes revoke existing sessions and rotate the current one. Public
+leaderboards and achievement catalogs are readable without login; history,
+result recording, and profile updates require a session. API inputs are bounded,
+rate-limited, origin-checked, normalized, and scored by the server.
+
+```mermaid
+erDiagram
+  USERS ||--o{ SESSIONS : has
+  USERS ||--o{ GAME_RESULTS : records
+  USERS ||--o{ ACHIEVEMENT_PROGRESS : earns
+  USERS { integer id PK
+    text gamertag UK
+    text passcode_hash
+  }
+  SESSIONS { text token_hash PK
+    integer user_id FK
+    text expires_at
+  }
+  GAME_RESULTS { integer id PK
+    integer user_id FK
+    text game
+    integer score
+    integer won
+    text details
+  }
+  ACHIEVEMENT_PROGRESS { integer user_id PK,FK
+    text achievement_id PK
+    integer progress
+    text unlocked_at
+  }
+```
+
+## Online gaming
+
+```mermaid
+sequenceDiagram
+  participant C1 as Player 1
+  participant API as Room-list REST API
+  participant WS as Game WebSocket endpoint
+  participant RM as In-memory room manager
+  participant C2 as Player 2
+  C1->>WS: create-room(public/private, passcode)
+  WS->>RM: create
+  WS-->>C1: room code + opaque resume token
+  C2->>API: list public rooms
+  API-->>C2: open public rooms
+  C2->>WS: join-room(code, passcode?)
+  WS->>RM: join
+  WS-->>C2: side + opaque resume token
+  C1->>WS: ready
+  C2->>WS: ready
+  loop match
+    C1->>WS: input / move / aim / fire
+    WS->>RM: validate and advance authoritative state
+    RM-->>C1: state
+    RM-->>C2: state
+  end
+  C2--xWS: disconnect
+  C2->>WS: resume(code, token)
+  WS-->>C1: peer reconnected
+```
+
+| Concern | Pong | Tic-tac-toe | Battle Tanks |
+|---|---|---|---|
+| Endpoint | `/ws` | `/ws/tictactoe` | `/ws/battle-tanks` |
+| Client command | continuous paddle input | discrete cell move | versioned move/aim/fire command |
+| State delivery | 30 Hz snapshots | after actions | 60 Hz simulation snapshots |
+| Result source | validated client report | validated client report | room manager records authenticated players |
+| Shared lifecycle | public/private five-character rooms, ready, rematch, invitation, resume token, reconnection grace, inactivity expiry, heartbeat |
+
+Rooms and resume tokens are ephemeral and vanish on expiry/restart. Account
+sessions are separate from room identity: login adds a gamertag to a room, and
+Battle Tanks also associates the user id for trusted online result recording.
+
+## Deployment and boundaries
+
+```mermaid
+flowchart LR
+  Internet --> TLS[Reverse proxy: TLS + WebSocket upgrade]
+  TLS --> C[Single unprivileged container :8080]
+  C --> V[(arcade-data volume)]
+  C --> H[/healthz]
+  subgraph Container
+    C --> Static[Static assets]
+    C --> API[REST API]
+    C --> WS[WebSocket server]
+  end
+```
+
+The server blocks private source/data paths, applies response security headers,
+checks HTTP/WebSocket origins, caps JSON and WebSocket payloads, and uses a
+heartbeat. Startup applies ordered SQL migrations transactionally. Graceful
+shutdown closes sockets and SQLite. See the [decision index](adr/README.md) for
+the trade-offs behind these boundaries.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,8 @@ sequenceDiagram
 Rooms and resume tokens are ephemeral and vanish on expiry/restart. Account
 sessions are separate from room identity: login adds a gamertag to a room, and
 Battle Tanks also associates the user id for trusted online result recording.
+See [online rendering](online-rendering.md) for snapshot smoothing, client-side
+prediction, safeguards, and alternatives.
 
 ## Deployment and boundaries
 

--- a/docs/online-rendering.md
+++ b/docs/online-rendering.md
@@ -1,0 +1,115 @@
+# Online rendering: smoothing and prediction
+
+The server remains authoritative. Clients predict only transient render
+positions between snapshots; commands, collisions, scores, damage, and turns
+are never predicted. Every new snapshot replaces the client model and therefore
+corrects accumulated visual error.
+
+```mermaid
+flowchart LR
+  I[Player intent] --> S[Authoritative server simulation]
+  S -->|periodic snapshot| C[Client snapshot copy]
+  C --> P[Short forward prediction]
+  P --> R[requestAnimationFrame render]
+  S -. next snapshot corrects drift .-> C
+```
+
+## Cadence and latency budget
+
+| Game | Authority | Snapshot delivery | Client horizon |
+|---|---|---|---|
+| Pong | Server physics with steps up to 1/120 s | 30 Hz | 75 ms maximum |
+| Battle Tanks | Server projectile physics at 60 Hz | 40 ms throttle: 25 Hz cap, typically about 20 Hz when sampled at 60 Hz | 100 ms maximum |
+| Tic-tac-toe | Server validates discrete moves | Event-driven | None needed |
+
+The horizon caps prevent a stalled or disconnected client from extrapolating
+indefinitely. They are deliberately only a little longer than the normal
+snapshot interval, so animation usually stays continuous while prediction error
+remains bounded.
+
+## Pong
+
+On receipt, the client copies balls, paddles, effect state, authoritative match
+elapsed time, and `performance.now()`. On every animation frame it predicts each
+ball from that immutable sample by the smaller of sample age and 75 ms.
+
+```mermaid
+sequenceDiagram
+  participant S as Server
+  participant C as Pong client
+  participant R as Renderer
+  S-->>C: sequenced state snapshot at 30 Hz
+  C->>C: discard stale sequence and copy sample
+  loop each animation frame
+    C->>C: age = min(now - receivedAt, 75 ms)
+    C->>C: replay ball physics in steps up to 1/120 s
+    C->>R: predicted ball copies
+  end
+  Note over C,R: paddles and non-ball state use the latest snapshot
+```
+
+Prediction mirrors the relevant authoritative rules: velocity, slow-field
+scaling and expiry, curve acceleration and duration, top/bottom wall rebounds,
+paddle overlap and return velocity, and one-shot curve consumption. Prediction
+clones balls and effects so rendering cannot mutate synchronized state. The next
+snapshot may visibly snap the ball if the prediction lacked future information,
+such as newly received input or an authoritative scoring event.
+
+## Battle Tanks
+
+Only a projectile in flight is extrapolated. Each state message replaces the
+authoritative UI state and stores a projectile copy plus receipt time. Rendering
+uses the closed-form ballistic position for at most 100 ms:
+
+```text
+x(t)  = x₀ + vx·t
+y(t)  = y₀ + vy·t + ½g·t²
+vy(t) = vy + g·t
+```
+
+```mermaid
+flowchart LR
+  Snapshot[Projectile snapshot] --> Copy[Immutable render sample]
+  Clock[Monotonic sample age capped at 100 ms] --> Ballistic[Ballistic projection]
+  Copy --> Ballistic --> Draw[Draw projectile]
+  Snapshot --> State[Authoritative tanks, health, phase and impacts]
+```
+
+The renderer does not run collision detection or resolve a shot. The server
+broadcasts an immediate resolved state on collision, turn change, or game over;
+that snapshot removes the predicted projectile and applies authoritative damage
+and impact effects. This avoids duplicate impacts and incorrect client turns.
+
+## Optimizations and safeguards
+
+* `requestAnimationFrame` decouples display refresh from network cadence.
+* Prediction starts from the newest copied snapshot rather than incrementally
+  mutating the prior rendered position, preventing frame-rate-dependent drift.
+* Pong uses bounded 1/120 s substeps to match collision behavior and avoid
+  tunneling; Battle Tanks uses a cheap analytical trajectory because collision
+  remains server-only.
+* Server snapshots are throttled independently of render refresh to control
+  bandwidth. Pong sends at 30 Hz; Battle Tanks sends only during projectile
+  flight and immediately on resolution.
+* Monotonic `performance.now()` measures local sample age without depending on
+  client/server wall-clock synchronization.
+* Sequence rejection protects Pong from out-of-order snapshots. Room lifecycle,
+  pause, and reconnection still come from authoritative messages.
+
+## Trade-offs and alternatives
+
+| Approach | Benefit | Reason not currently used |
+|---|---|---|
+| Current short extrapolation | Low latency, little buffering, small change to authoritative design | Corrections can snap at unpredictable collisions or input changes |
+| Snapshot interpolation with a render delay | Smooth motion and no future-state guessing | Adds at least one snapshot interval of visible latency; needs a timestamped buffer |
+| Blend corrections over several frames | Hides small snapshot corrections | Temporarily renders a state known to be wrong and complicates collision/score transitions |
+| Full client-side simulation and reconciliation | Immediate local response for all objects | Requires deterministic replay, input acknowledgements, rollback, and substantially more complexity |
+| Higher snapshot rate | Smaller prediction gaps and corrections | Increases room bandwidth, serialization, and broadcast work |
+| Lower snapshot rate plus richer velocity data | Reduces bandwidth | Lengthens prediction horizons and magnifies divergence at discontinuities |
+
+The current design favors responsive visuals with bounded complexity. If network
+jitter becomes the dominant problem, timestamped interpolation is the preferred
+next experiment for remote objects. If input latency becomes dominant, add
+sequence-numbered local input prediction and server reconciliation separately;
+do not move authority for collisions or results into the browser.
+


### PR DESCRIPTION
### Motivation

- Provide a compact, diagram-first description of the system topology, browser and server subsystems (accounts, achievements, results, room managers), and deployment boundaries so new contributors can understand runtime responsibilities at a glance.
- Record the rationale behind key design choices in short ADRs to preserve trade-offs and make future changes easier to evaluate.

### Description

- Add a new `docs/` hub with `architecture.md` that maps the browser shell, Node process, room managers, SQLite persistence and deployment topology using multiple `mermaid` diagrams and sequence/ER views.
- Add `docs/adr/` with seven concise ADR files (`0001`–`0007`) documenting decisions about the build-free client, SQLite migrations, server-side scoring and achievements, authoritative ephemeral rooms, session boundaries, preserving classic games, and same-origin security, plus an `adr/README.md` index.
- Add `docs/README.md` that points to the architecture map and ADR index so the documentation is discoverable from the repo root.
- Files created: `docs/README.md`, `docs/architecture.md`, and `docs/adr/0001-*` through `0007-*` and `docs/adr/README.md`.

### Testing

- Ran `npm test` (the repository test suite via `node --test`) and all tests completed successfully. 
- Ran repository checks including `git diff --check` with no issues reported. 
- Ran an automated Markdown/link check which reported relative Markdown links OK and counted `14` `mermaid` diagrams in the new docs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7df04194808320869d37462cc9493e)