### PR TITLE
Use shared top bar for branding and scope profile controls to `.shell`

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,8 +39,6 @@
             --sky-blue: #27b4ff;
             --lime: #8bdc3c;
             --orange: #ff7a3d;
-            --brand-start: #a50050;
-            --brand-end: #4c25c7;
         }
 
         :root[data-theme="dark"] {
@@ -66,8 +64,6 @@
             --sky-blue: #53c3ff;
             --lime: #a4e85f;
             --orange: #ff9363;
-            --brand-start: var(--hot-pink);
-            --brand-end: var(--accent);
         }
 
         * { box-sizing: border-box; }
@@ -103,38 +99,6 @@
             mask-image: linear-gradient(to bottom, black, transparent 72%);
             pointer-events: none;
         }
-
-        header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 24px;
-            margin-bottom: clamp(60px, 9vw, 104px);
-        }
-
-        .brand {
-            display: inline-flex;
-            align-items: center;
-            gap: 11px;
-            font-weight: 900;
-            letter-spacing: -0.035em;
-        }
-
-        .brand-mark {
-            display: grid;
-            width: 42px;
-            height: 42px;
-            place-items: center;
-            color: var(--accent-contrast);
-            background: linear-gradient(135deg, var(--brand-start), var(--brand-end));
-            border: 3px solid var(--ink);
-            border-radius: 13px;
-            box-shadow: 4px 4px 0 var(--ink);
-            font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
-            font-size: 14px;
-        }
-
-        .header-note { padding: 9px 14px; color: var(--ink); background: var(--sunshine); border: 2px solid var(--ink); border-radius: 999px; box-shadow: 3px 3px 0 var(--ink); font-size: 13px; font-weight: 850; transform: rotate(2deg); }
 
         .eyebrow {
             display: inline-block;
@@ -318,8 +282,6 @@
 
         @media (max-width: 700px) {
             .shell { width: min(100% - 28px, 1120px); padding-top: 22px; }
-            header { margin-bottom: 72px; }
-            .header-note { display: none; }
             .intro { margin-bottom: 42px; }
             .game-grid { grid-template-columns: 1fr; }
             .card { min-height: 0; border-radius: 22px; }
@@ -335,11 +297,6 @@
 </head>
 <body>
     <main class="shell">
-        <header>
-            <div class="brand"><span class="brand-mark" aria-hidden="true">JS</span> JavaScript Arcade</div>
-            <span class="header-note">Small games, thoughtfully rebuilt.</span>
-        </header>
-
         <section class="hero" aria-labelledby="page-title">
             <p class="eyebrow">Pick a game</p>
             <h1 id="page-title">Your next <span class="pop">high score</span> starts here.</h1>

--- a/profile.css
+++ b/profile.css
@@ -81,12 +81,12 @@ h2 { margin-top: 0; font-size: clamp(25px, 4vw, 34px); }
 .stat-metrics div + div { padding-left: 14px; border-left: 1px solid color-mix(in srgb, var(--ink) 18%, transparent); }
 .stat-metrics strong { display: block; font-size: 26px; line-height: 1.1; }
 .stat-metrics small { display: block; margin-top: 5px; color: var(--muted); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
-form { display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: 10px; }
-input, select, button { min-height: 44px; padding: 11px 13px; color: inherit; background: var(--field); border: 2px solid var(--ink); border-radius: 12px; font: inherit; }
-button { color: #fff; background: var(--button); box-shadow: 3px 3px 0 var(--ink); font-weight: 900; cursor: pointer; }
-button:hover:not(:disabled) { background: var(--button-hover); box-shadow: 1px 1px 0 var(--ink); transform: translate(2px, 2px); }
-button:disabled { opacity: .45; cursor: default; }
-:where(a, button, input, select):focus-visible { outline: 4px solid var(--sky); outline-offset: 3px; }
+.shell form { display: grid; grid-template-columns: 1fr 1fr 1fr auto; gap: 10px; }
+.shell :where(input, select, button) { min-height: 44px; padding: 11px 13px; color: inherit; background: var(--field); border: 2px solid var(--ink); border-radius: 12px; font: inherit; }
+.shell button { color: #fff; background: var(--button); box-shadow: 3px 3px 0 var(--ink); font-weight: 900; cursor: pointer; }
+.shell button:hover:not(:disabled) { background: var(--button-hover); box-shadow: 1px 1px 0 var(--ink); transform: translate(2px, 2px); }
+.shell button:disabled { opacity: .45; cursor: default; }
+.shell :where(a, button, input, select):focus-visible { outline: 4px solid var(--sky); outline-offset: 3px; }
 .table-wrap { overflow: auto; border: 2px solid var(--ink); border-radius: 16px; background: var(--stat); }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 14px 12px; text-align: left; border-bottom: 1px solid color-mix(in srgb, var(--ink) 16%, transparent); }
@@ -109,12 +109,12 @@ th { color: var(--muted); font-size: 11px; letter-spacing: .08em; text-transform
 .profile-achievement small, .profile-achievement p { color: var(--muted); }
 .profile-achievement p { margin: 4px 0; font-size: 13px; }
 .profile-achievement progress { width: 100%; accent-color: var(--accent); }
-@media (max-width: 820px) { form { grid-template-columns: 1fr 1fr; } form button { grid-column: 1 / -1; } }
+@media (max-width: 820px) { .shell form { grid-template-columns: 1fr 1fr; } .shell form button { grid-column: 1 / -1; } }
 @media (max-width: 650px) {
     .shell { width: min(100% - 20px, 560px); }
     .hero { margin-top: 50px; }
     .hero-spark { display: none; }
-    .grid, .profile-achievements, form { grid-template-columns: 1fr; }
+    .grid, .profile-achievements, .shell form { grid-template-columns: 1fr; }
     .panel { padding: 21px 16px; border-radius: 22px; box-shadow: 5px 5px 0 var(--ink); }
     .tabs { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .tabs button { min-width: 0; padding-inline: 8px; font-size: 13px; }

--- a/tests/homepage-theme.test.js
+++ b/tests/homepage-theme.test.js
@@ -13,24 +13,16 @@ test('homepage defines distinct light and dark palettes', () => {
     assert.match(homepage, /--page-background:\s*#0d1420;/);
 });
 
-test('light theme brand mark uses a high-contrast gradient behind its white label', () => {
-    const relativeLuminance = hex => {
-        const channels = hex.match(/[\da-f]{2}/gi).map(value => parseInt(value, 16) / 255);
-        const linear = channels.map(value => value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4);
-        return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
-    };
-    const contrastWithWhite = hex => 1.05 / (relativeLuminance(hex) + 0.05);
-    const stops = [...homepage.matchAll(/--brand-(?:start|end):\s*(#[\da-f]{6})/gi)].map(match => match[1]);
-
-    assert.deepEqual(stops, ['#a50050', '#4c25c7']);
-    assert.ok(stops.every(stop => contrastWithWhite(stop) >= 4.5));
-    assert.match(homepage, /linear-gradient\(135deg, var\(--brand-start\), var\(--brand-end\)\)/);
-});
-
 test('homepage surfaces use theme palette variables', () => {
     assert.match(homepage, /background:[^;}]*var\(--page-background\);/s);
     assert.match(homepage, /background:\s*var\(--panel\);/);
     assert.match(homepage, /box-shadow:\s*0 24px 70px var\(--card-shadow\);/);
+});
+
+test('homepage relies on the shared top bar for its brand', () => {
+    assert.doesNotMatch(homepage, /<header>/);
+    assert.doesNotMatch(homepage, /class="brand(?:-mark)?"/);
+    assert.match(homepage, /src="arcade\.js"/);
 });
 
 test('homepage gives every game card the same grid footprint', () => {

--- a/tests/profile-page.test.js
+++ b/tests/profile-page.test.js
@@ -22,6 +22,12 @@ test('profile uses the playful arcade shell and card language', () => {
     assert.match(styles, /\.panel::before/);
 });
 
+test('profile controls do not restyle the shared top bar', () => {
+    assert.match(styles, /\.shell :where\(input, select, button\)/);
+    assert.match(styles, /\.shell button\s*\{/);
+    assert.doesNotMatch(styles, /(?:^|\n)button\s*\{/);
+});
+
 test('profile includes accessible game-history pagination', () => {
     assert.match(profile, /id="history-pagination" aria-label="Game history pages"/);
     assert.match(profile, /data-page-action="previous"/);


### PR DESCRIPTION
### Motivation
- The homepage was rendering a local header/brand and the profile stylesheet used global form/button selectors, causing a duplicated top bar on the homepage and inconsistent top-bar styling on the profile page.
- The intended behaviour is for every page to consume a single shared arcade top bar and for page-specific styles to avoid leaking into shared navigation controls.

### Description
- Removed the local header markup and its page-level header/brand styles from `index.html` so pages rely on the shared arcade navigation surface.
- Removed page-level brand gradient variables from `index.html` to avoid duplicating branding that belongs to the shared styles.
- Scoped profile form and control selectors by prefixing them with `.shell` in `profile.css` to prevent profile-specific button and focus styles from affecting the shared top bar.
- Updated tests in `tests/homepage-theme.test.js` and `tests/profile-page.test.js` to add regression checks that the homepage does not include a local `<header>` and that profile controls do not globally restyle top-bar buttons.

### Testing
- Ran `npm test` (Node's built-in test runner) and all automated tests passed (`101 passed, 0 failed`).
- Ran `npm run check` (static `node --check` validations) and it completed without errors.
- Ran repository checks including `git diff --check` and `git status` and there were no outstanding style or syntax issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a815fe840788320b5cb45b45fc68162)