### PR TITLE
Enforce a route-aware content security policy

### DIFF
--- a/Minesweeper/classic/index.html
+++ b/Minesweeper/classic/index.html
@@ -4,7 +4,7 @@
     <head>
         <title>Minesweeper!</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-        <script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/tile.js" type="text/javascript"></script>
         <link rel="icon" href="../../icon.svg" type="image/svg+xml">

--- a/docs/adr/0007-same-origin-security.md
+++ b/docs/adr/0007-same-origin-security.md
@@ -16,7 +16,7 @@ flowchart LR
 **Consequences:** Cookies and invitation URLs stay simple and the attack surface
 is constrained; split-origin clients require configuration and proxy trust must
 match the actual network boundary. Modern pages execute scripts only from the
-arcade origin. Preserved classic p5.js pages receive a route-scoped cdnjs
-exception, while inline scripts, plugin objects, frames, and foreign form targets
-remain blocked.
+arcade origin. Resolved assets belonging to preserved classic p5.js pages receive
+a scoped cdnjs exception, while inline scripts, plugin objects, frames, and
+foreign form targets remain blocked.
 

--- a/docs/adr/0007-same-origin-security.md
+++ b/docs/adr/0007-same-origin-security.md
@@ -15,5 +15,8 @@ flowchart LR
 
 **Consequences:** Cookies and invitation URLs stay simple and the attack surface
 is constrained; split-origin clients require configuration and proxy trust must
-match the actual network boundary.
+match the actual network boundary. Modern pages execute scripts only from the
+arcade origin. Preserved classic p5.js pages receive a route-scoped cdnjs
+exception, while inline scripts, plugin objects, frames, and foreign form targets
+remain blocked.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,7 +305,7 @@ flowchart LR
 ```
 
 The server blocks private source/data paths, applies response security headers
-and a route-aware Content Security Policy,
+and a resolved-asset-aware Content Security Policy,
 checks HTTP/WebSocket origins, caps JSON and WebSocket payloads, and uses a
 heartbeat. WebSocket admission also bounds connections, messages, lobby
 actions, active rooms, and public listings before unauthenticated work can grow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -304,7 +304,8 @@ flowchart LR
   C --> V[(arcade-data volume)]
 ```
 
-The server blocks private source/data paths, applies response security headers,
+The server blocks private source/data paths, applies response security headers
+and a route-aware Content Security Policy,
 checks HTTP/WebSocket origins, caps JSON and WebSocket payloads, and uses a
 heartbeat. WebSocket admission also bounds connections, messages, lobby
 actions, active rooms, and public listings before unauthenticated work can grow

--- a/pong/classic/index.html
+++ b/pong/classic/index.html
@@ -4,7 +4,7 @@
     <head>
         <title>PONG!</title>
         <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-        <script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js" type="text/javascript"></script>
         <script src="scripts/sketch.js" type="text/javascript"></script>
         <script src="scripts/board.js" type="text/javascript"></script>
         <script src="scripts/ball.js" type="text/javascript"></script>

--- a/server/http-security.js
+++ b/server/http-security.js
@@ -53,6 +53,27 @@ function originAllowed(request, allowedOrigins, trustProxy = false, requireOrigi
     return origin === requestOrigin(request, trustProxy) || allowedOrigins.includes(origin);
 }
 
+function contentSecurityPolicy(pathname = '') {
+    const classicGame = /^\/(?:Sudoku|Minesweeper|pong)\/classic(?:\/|$)/.test(pathname);
+    const scriptSources = classicGame ? "'self' https://cdnjs.cloudflare.com" : "'self'";
+    return [
+        "default-src 'self'",
+        `script-src ${scriptSources}`,
+        "script-src-attr 'none'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: blob:",
+        "connect-src 'self' ws: wss:",
+        "font-src 'self'",
+        "object-src 'none'",
+        "base-uri 'none'",
+        "frame-ancestors 'none'",
+        "frame-src 'none'",
+        "form-action 'self'",
+        "manifest-src 'self'",
+        "worker-src 'self'"
+    ].join('; ');
+}
+
 function isPrivatePath(pathname) {
     const segments = pathname.split('/').filter(Boolean);
     if (segments.some(segment => segment.startsWith('.'))) return true;
@@ -162,4 +183,4 @@ class WebSocketGuard {
     ownRoom(socket, room) { this.roomOwners.set(room, this.socketIps.get(socket) || 'unknown'); }
 }
 
-module.exports = { clientIp, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard };
+module.exports = { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard };

--- a/server/http-security.js
+++ b/server/http-security.js
@@ -53,8 +53,8 @@ function originAllowed(request, allowedOrigins, trustProxy = false, requireOrigi
     return origin === requestOrigin(request, trustProxy) || allowedOrigins.includes(origin);
 }
 
-function contentSecurityPolicy(pathname = '') {
-    const classicGame = /^\/(?:Sudoku|Minesweeper|pong)\/classic(?:\/|$)/.test(pathname);
+function contentSecurityPolicy(assetPath = '') {
+    const classicGame = /^(?:Sudoku|Minesweeper|pong)\/classic(?:\/|$)/.test(assetPath);
     const scriptSources = classicGame ? "'self' https://cdnjs.cloudflare.com" : "'self'";
     return [
         "default-src 'self'",

--- a/server/index.js
+++ b/server/index.js
@@ -84,7 +84,7 @@ const server = http.createServer(async (request, response) => {
     let pathname;
     try { pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname); }
     catch { response.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' }).end('Bad request'); return; }
-    response.setHeader('content-security-policy', contentSecurityPolicy(pathname));
+    response.setHeader('content-security-policy', contentSecurityPolicy());
     if (pathname === '/healthz') {
         response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
         response.end(JSON.stringify({ status: 'ok', rooms: rooms.rooms.size }));
@@ -150,6 +150,8 @@ const server = http.createServer(async (request, response) => {
     try {
         if (fs.statSync(filePath).isDirectory()) filePath = path.join(filePath, 'index.html');
     } catch { /* handled by readFile */ }
+    const assetPath = path.relative(root, filePath).split(path.sep).join('/');
+    response.setHeader('content-security-policy', contentSecurityPolicy(assetPath));
     fs.readFile(filePath, (error, content) => {
         if (error) { response.writeHead(error.code === 'ENOENT' ? 404 : 500).end(error.code === 'ENOENT' ? 'Not found' : 'Server error'); return; }
         response.writeHead(200, { 'content-type': mime[path.extname(filePath)] || 'application/octet-stream' });

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const { BattleTanksRooms } = require('./battle-tanks-rooms');
 const { openDatabase } = require('./database');
 const { Accounts } = require('./accounts');
 const { Achievements } = require('./achievements');
-const { clientIp: getClientIp, isPrivatePath, originAllowed, parseCookies, RateLimiter, WebSocketGuard } = require('./http-security');
+const { clientIp: getClientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, WebSocketGuard } = require('./http-security');
 const { generateIcons } = require('../scripts/generate-icons');
 
 const root = path.resolve(__dirname, '..');
@@ -84,6 +84,7 @@ const server = http.createServer(async (request, response) => {
     let pathname;
     try { pathname = decodeURIComponent(new URL(request.url, 'http://localhost').pathname); }
     catch { response.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' }).end('Bad request'); return; }
+    response.setHeader('content-security-policy', contentSecurityPolicy(pathname));
     if (pathname === '/healthz') {
         response.writeHead(200, { 'content-type': 'application/json', 'cache-control': 'no-store' });
         response.end(JSON.stringify({ status: 'ok', rooms: rooms.rooms.size }));

--- a/tests/http-security.test.js
+++ b/tests/http-security.test.js
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
+const path = require('node:path');
 const { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard } = require('../server/http-security');
 
 function request(headers = {}, encrypted = false) {
@@ -30,7 +31,7 @@ test('origin checks can require the header for WebSocket handshakes', () => {
 });
 
 test('content security policy keeps modern scripts local and narrowly permits the classic CDN', () => {
-    const modern = contentSecurityPolicy('/pong/');
+    const modern = contentSecurityPolicy('pong/index.html');
     assert.match(modern, /default-src 'self'/);
     assert.match(modern, /script-src 'self';/);
     assert.match(modern, /script-src-attr 'none'/);
@@ -38,11 +39,16 @@ test('content security policy keeps modern scripts local and narrowly permits th
     assert.match(modern, /frame-ancestors 'none'/);
     assert.match(modern, /form-action 'self'/);
     assert.doesNotMatch(modern, /cdnjs/);
-    for (const [pathname, file] of [['/pong/classic/', 'pong/classic/index.html'], ['/Minesweeper/classic/index.html', 'Minesweeper/classic/index.html'], ['/Sudoku/classic/', 'Sudoku/classic/index.html']]) {
-        assert.match(contentSecurityPolicy(pathname), /script-src 'self' https:\/\/cdnjs\.cloudflare\.com;/, pathname);
+    for (const file of ['pong/classic/index.html', 'Minesweeper/classic/index.html', 'Sudoku/classic/index.html']) {
+        assert.match(contentSecurityPolicy(file), /script-src 'self' https:\/\/cdnjs\.cloudflare\.com;/, file);
         assert.doesNotMatch(fs.readFileSync(file, 'utf8'), /src="\/\/cdnjs\.cloudflare\.com/);
     }
-    assert.doesNotMatch(contentSecurityPolicy('/classic-looking/path'), /cdnjs/);
+    assert.doesNotMatch(contentSecurityPolicy('classic-looking/path'), /cdnjs/);
+    const root = path.resolve(__dirname, '..');
+    const traversal = decodeURIComponent('/pong/classic/%2e%2e%2f%2e%2e%2findex.html');
+    const resolvedAsset = path.relative(root, path.resolve(root, `.${traversal}`)).split(path.sep).join('/');
+    assert.equal(resolvedAsset, 'index.html');
+    assert.doesNotMatch(contentSecurityPolicy(resolvedAsset), /cdnjs/);
 });
 
 test('trusted proxy addresses must be valid and use the proxy-adjacent value', () => {

--- a/tests/http-security.test.js
+++ b/tests/http-security.test.js
@@ -3,7 +3,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
-const { clientIp, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard } = require('../server/http-security');
+const fs = require('node:fs');
+const { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard } = require('../server/http-security');
 
 function request(headers = {}, encrypted = false) {
     return { headers, socket: { encrypted, remoteAddress: '127.0.0.1' } };
@@ -26,6 +27,22 @@ test('origin checks can require the header for WebSocket handshakes', () => {
     const withoutOrigin = request({ host: 'arcade.test' });
     assert.equal(originAllowed(withoutOrigin, [], false), true, 'ordinary non-browser API clients remain supported');
     assert.equal(originAllowed(withoutOrigin, [], false, true), false, 'WebSocket handshakes must identify their origin');
+});
+
+test('content security policy keeps modern scripts local and narrowly permits the classic CDN', () => {
+    const modern = contentSecurityPolicy('/pong/');
+    assert.match(modern, /default-src 'self'/);
+    assert.match(modern, /script-src 'self';/);
+    assert.match(modern, /script-src-attr 'none'/);
+    assert.match(modern, /object-src 'none'/);
+    assert.match(modern, /frame-ancestors 'none'/);
+    assert.match(modern, /form-action 'self'/);
+    assert.doesNotMatch(modern, /cdnjs/);
+    for (const [pathname, file] of [['/pong/classic/', 'pong/classic/index.html'], ['/Minesweeper/classic/index.html', 'Minesweeper/classic/index.html'], ['/Sudoku/classic/', 'Sudoku/classic/index.html']]) {
+        assert.match(contentSecurityPolicy(pathname), /script-src 'self' https:\/\/cdnjs\.cloudflare\.com;/, pathname);
+        assert.doesNotMatch(fs.readFileSync(file, 'utf8'), /src="\/\/cdnjs\.cloudflare\.com/);
+    }
+    assert.doesNotMatch(contentSecurityPolicy('/classic-looking/path'), /cdnjs/);
 });
 
 test('trusted proxy addresses must be valid and use the proxy-adjacent value', () => {


### PR DESCRIPTION
## Summary
- send a restrictive Content Security Policy on every HTTP response
- keep modern scripts same-origin while narrowly allowing cdnjs on preserved classic p5.js routes
- make classic CDN URLs explicitly HTTPS and document the policy boundary

## Verification
- node --test (243 passing)
- project syntax checks
- git diff --check
- live browser smoke tests for modern Pong and classic Pong, Minesweeper, and Sudoku (no console errors; classic canvases rendered)