### PR TITLE
Secure production session cookies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ proxy-adjacent forwarded client address and origin checks use the forwarded
 protocol. Leave it false if clients can connect directly to the container port
 and supply their own forwarding headers.
 
+The production image always marks session cookies `Secure`; this cannot be
+disabled with `COOKIE_SECURE=false`. The local Compose profile defaults to
+`NODE_ENV=development` so authentication remains available over localhost HTTP.
+Set `COOKIE_SECURE=true` to opt a non-production HTTPS environment into secure
+cookies.
+
 Authentication attempts are throttled by client address and gamertag, and
 passcode hashing runs asynchronously so it does not block game simulation.
 Scores are derived by the server from validated result fields rather than

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,7 @@ services:
     ports:
       - "${PONG_PORT:-8080}:8080"
     environment:
+      NODE_ENV: ${NODE_ENV:-development}
       PORT: 8080
       DATABASE_PATH: /app/data/arcade.sqlite
       RECONNECT_GRACE_MS: ${RECONNECT_GRACE_MS:-15000}

--- a/docs/adr/0007-same-origin-security.md
+++ b/docs/adr/0007-same-origin-security.md
@@ -18,5 +18,7 @@ is constrained; split-origin clients require configuration and proxy trust must
 match the actual network boundary. Modern pages execute scripts only from the
 arcade origin. Resolved assets belonging to preserved classic p5.js pages receive
 a scoped cdnjs exception, while inline scripts, plugin objects, frames, and
-foreign form targets remain blocked.
+foreign form targets remain blocked. Production session and deletion cookies
+always carry the `Secure` attribute; development deployments may opt into it but
+cannot opt production out.
 

--- a/server/http-security.js
+++ b/server/http-security.js
@@ -74,6 +74,10 @@ function contentSecurityPolicy(assetPath = '') {
     ].join('; ');
 }
 
+function useSecureCookies(environment = process.env) {
+    return environment.NODE_ENV === 'production' || environment.COOKIE_SECURE === 'true';
+}
+
 function isPrivatePath(pathname) {
     const segments = pathname.split('/').filter(Boolean);
     if (segments.some(segment => segment.startsWith('.'))) return true;
@@ -183,4 +187,4 @@ class WebSocketGuard {
     ownRoom(socket, room) { this.roomOwners.set(room, this.socketIps.get(socket) || 'unknown'); }
 }
 
-module.exports = { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard };
+module.exports = { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, useSecureCookies, WebSocketGuard };

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const { BattleTanksRooms } = require('./battle-tanks-rooms');
 const { openDatabase } = require('./database');
 const { Accounts } = require('./accounts');
 const { Achievements } = require('./achievements');
-const { clientIp: getClientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, WebSocketGuard } = require('./http-security');
+const { clientIp: getClientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, useSecureCookies, WebSocketGuard } = require('./http-security');
 const { generateIcons } = require('../scripts/generate-icons');
 
 const root = path.resolve(__dirname, '..');
@@ -60,7 +60,8 @@ function json(response, status, body, headers = {}) {
 }
 function cookies(request) { return parseCookies(request.headers.cookie); }
 function sessionUser(request) { return accounts.userForToken(cookies(request).arcade_session); }
-function sessionCookie(token, expiresAt) { return `arcade_session=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict; Expires=${new Date(expiresAt).toUTCString()}${process.env.COOKIE_SECURE === 'true' ? '; Secure' : ''}`; }
+function cookieSecurity() { return useSecureCookies() ? '; Secure' : ''; }
+function sessionCookie(token, expiresAt) { return `arcade_session=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Strict; Expires=${new Date(expiresAt).toUTCString()}${cookieSecurity()}`; }
 const loginLimiter = new RateLimiter(10, 15 * 60 * 1000);
 const loginIpLimiter = new RateLimiter(50, 15 * 60 * 1000);
 const registrationLimiter = new RateLimiter(5, 60 * 60 * 1000);
@@ -116,7 +117,7 @@ const server = http.createServer(async (request, response) => {
             }
             if (pathname === '/api/auth/logout' && request.method === 'POST') {
                 accounts.deleteSession(cookies(request).arcade_session);
-                return json(response, 200, { ok: true }, { 'set-cookie': 'arcade_session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0' });
+                return json(response, 200, { ok: true }, { 'set-cookie': `arcade_session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0${cookieSecurity()}` });
             }
             if (pathname === '/api/me' && request.method === 'GET') return json(response, 200, { user: sessionUser(request) });
             const leaderboard = pathname.match(/^\/api\/leaderboards\/(pong|sudoku|minesweeper|tictactoe|battletanks|tetris)$/);

--- a/tests/http-security.test.js
+++ b/tests/http-security.test.js
@@ -5,7 +5,7 @@ const assert = require('node:assert/strict');
 const { EventEmitter } = require('node:events');
 const fs = require('node:fs');
 const path = require('node:path');
-const { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, WebSocketGuard } = require('../server/http-security');
+const { clientIp, contentSecurityPolicy, isPrivatePath, originAllowed, parseCookies, RateLimiter, requestOrigin, useSecureCookies, WebSocketGuard } = require('../server/http-security');
 
 function request(headers = {}, encrypted = false) {
     return { headers, socket: { encrypted, remoteAddress: '127.0.0.1' } };
@@ -14,6 +14,14 @@ function request(headers = {}, encrypted = false) {
 test('cookie parsing tolerates malformed values and preserves equals signs', () => {
     assert.deepEqual(parseCookies('session=a%3Db; broken=%E0%A4%A; theme=dark'), { session: 'a=b', theme: 'dark' });
     assert.deepEqual(parseCookies('arcade_session=first; arcade_session=second'), { arcade_session: 'first' });
+});
+
+test('production cookies are always secure while development can opt in', () => {
+    assert.equal(useSecureCookies({ NODE_ENV: 'production' }), true);
+    assert.equal(useSecureCookies({ NODE_ENV: 'production', COOKIE_SECURE: 'false' }), true);
+    assert.equal(useSecureCookies({ NODE_ENV: 'development' }), false);
+    assert.equal(useSecureCookies({ NODE_ENV: 'development', COOKIE_SECURE: 'false' }), false);
+    assert.equal(useSecureCookies({ NODE_ENV: 'development', COOKIE_SECURE: 'true' }), true);
 });
 
 test('origin checks use direct connection details unless the proxy is trusted', () => {


### PR DESCRIPTION
## Summary
- make NODE_ENV=production always add Secure to session cookies, even when COOKIE_SECURE is unset or false
- apply the same attributes to logout cookie deletion
- preserve localhost HTTP development through an explicit Compose development default and document the deployment contract

## Verification
- node --test (244 passing)
- project syntax checks
- git diff --check
- live production-mode registration and logout with COOKIE_SECURE=false; both Set-Cookie responses included Secure