### PR TITLE
Upgrade container runtime to Node 26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS dependencies
+FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3 AS dependencies
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
-FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
+FROM node:26-alpine@sha256:2d984a15c9b54fd0aeb608b8e0d0d83529eb34d2966db27a1fb4f1edc3d298a3
 ARG BUILD_VERSION=dev
 ENV NODE_ENV=production PORT=8080
 ENV BUILD_VERSION=${BUILD_VERSION}

--- a/tests/supply-chain.test.js
+++ b/tests/supply-chain.test.js
@@ -15,7 +15,7 @@ test('container stages use one immutable multi-platform Node image digest', () =
     const dockerfile = fs.readFileSync('Dockerfile', 'utf8');
     const images = [...dockerfile.matchAll(/^FROM\s+(node:[^\s]+)(?:\s+AS\s+\S+)?$/gmi)].map(match => match[1]);
     assert.equal(images.length, 2);
-    for (const image of images) assert.match(image, /^node:24-alpine@sha256:[0-9a-f]{64}$/, image);
+    for (const image of images) assert.match(image, /^node:26-alpine@sha256:[0-9a-f]{64}$/, image);
     assert.equal(new Set(images).size, 1);
     assert.match(dockerfile, /apk add --no-cache --upgrade libcrypto3=\d+\.\d+\.\d+-r\d+ libssl3=\d+\.\d+\.\d+-r\d+/);
     assert.match(dockerfile, /rm -rf \/usr\/local\/lib\/node_modules\/npm \/usr\/local\/lib\/node_modules\/corepack \/opt\/yarn-v\*/);


### PR DESCRIPTION
## Summary
- upgrade both container stages from digest-pinned Node 24 Alpine to digest-pinned Node 26 Alpine
- update the explicit supply-chain policy assertion to approve Node 26 while preserving the major-version review gate
- supersede closed Dependabot PR #92

## Verification
- 
ode --test tests/supply-chain.test.js
- 
ode --test (248 passed)
- all JavaScript syntax checks from 
pm run check executed directly with Node 26.8.1

The local machine does not have Docker installed, so the PR workflow will perform the container build and Trivy validation.