### PR TITLE
Use Korobeiniki for Tetris music

### DIFF
--- a/docs/adr/0013-procedural-arcade-audio.md
+++ b/docs/adr/0013-procedural-arcade-audio.md
@@ -3,7 +3,8 @@
 ## Status
 
 Accepted. ADR 0015 amends the open-dialog lifecycle rule for the dedicated
-sound mixer; all other decisions in this record remain current.
+sound mixer. ADR 0020 permits a documented public-domain melody as Tetris
+background music; all other decisions in this record remain current.
 
 ## Context
 

--- a/docs/adr/0020-tetris-korobeiniki-music.md
+++ b/docs/adr/0020-tetris-korobeiniki-music.md
@@ -1,0 +1,36 @@
+# 0020: Use Korobeiniki for Tetris background music
+
+## Status
+
+Accepted. This record amends ADR 0013's requirement that normal-gameplay lead
+phrases be original. Its procedural-audio, presentation, and provenance rules
+remain current.
+
+## Context
+
+The Tetris experience should use the recognizable “Korobeiniki” melody during
+active play. The melody is a traditional Russian folk song published in the
+nineteenth century, but modern recordings and arrangements can carry separate
+rights. The arcade also intentionally ships no audio or MIDI assets.
+
+## Decision
+
+The Tetris track in `scripts/audio.js` manually transcribes the opening eight
+bars from the public-domain 1861 score linked in `docs/audio.md` and transposes
+them from E minor to A minor for the existing synthesizer range. The bass,
+harmony, percussion, timbres, and intensity response remain an original
+procedural arrangement. No notes, audio, MIDI, or production choices are copied
+from a modern Tetris soundtrack or another arrangement.
+
+The shared audio scheduler may honor explicit multi-step note lengths for this
+phrased track. All sound remains presentation-only, begins after player
+interaction, uses the shared mixer and voice ceiling, and suspends under the
+existing lifecycle rules.
+
+## Consequences
+
+- Tetris active play has a familiar melodic identity across experience themes.
+- The arcade retains its build-free, offline-capable, asset-free audio system.
+- Provenance is reviewable independently from any copyrighted recording or
+  modern arrangement.
+- Other games continue using their original procedural lead phrases.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,3 +23,4 @@ All records describe the current system retrospectively and have status
 17. [Bound WebSocket and room resources](0017-websocket-resource-limits.md) — **Accepted**; layered connection, message, lobby, room, and listing limits constrain unauthenticated resource consumption.
 18. [Pin build dependencies to immutable revisions](0018-immutable-build-dependencies.md) — **Accepted**; GitHub Actions and multi-platform container bases resolve to reviewed commit SHAs and registry digests instead of movable tags.
 19. [Continuously scan the built container](0019-continuous-container-vulnerability-scanning.md) — **Accepted**; a pinned scanner rejects fixable high or critical vulnerabilities on changes and rescans daily without publishing.
+20. [Use Korobeiniki for Tetris background music](0020-tetris-korobeiniki-music.md) — **Accepted**; Tetris procedurally synthesizes a documented public-domain folk melody with an original accompaniment and no media asset.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -7,8 +7,9 @@ be muted or mixed from the shared arcade controls.
 
 ## Musical approach
 
-Normal gameplay uses original procedural arrangements written for this arcade.
-Each game combines a longer lead phrase with moving bass, chord changes, subtle
+Normal gameplay uses procedural arrangements written for this arcade. Lead
+phrases are original except for Tetris, which uses a documented public-domain
+folk melody. Each game combines its lead with moving bass, chord changes, subtle
 swing, and synthesized percussion while the shared experience theme changes its
 timbre:
 
@@ -19,9 +20,9 @@ timbre:
 Music reacts lightly to progress, pace, or danger. It does not affect mechanics,
 online state, results, or scoring.
 
-## Public-domain milestone fragments
+## Public-domain quotations
 
-The following short note sequences are manually encoded in `scripts/audio.js`.
+The following note sequences are manually encoded in `scripts/audio.js`.
 Only the composition and a public-domain typeset score are used; no audio or MIDI
 from the source is included.
 
@@ -30,6 +31,7 @@ from the source is included.
 | Sudoku completion | Opening C-major arpeggio, eight notes from the first measure of J. S. Bach's BWV 846 Prelude | [Mutopia edition](https://www.mutopiaproject.org/cgibin/piece-info.cgi?id=5), marked Public Domain |
 | General victory | Opening fifteen-note melody from Beethoven's “Ode to Joy” | [Mutopia edition](https://www.mutopiaproject.org/cgibin/piece-info.cgi?id=528), marked Public Domain |
 | Four-line Tetris clear | Five-note opening turn from Mozart's “Rondo Alla Turca” | [Mutopia score](https://www.mutopiaproject.org/ftp/MozartWA/KV331/KV331_3_RondoAllaTurca/KV331_3_RondoAllaTurca-let.pdf), placed in the public domain by the typesetter |
+| Tetris background | Opening eight-bar melody of the traditional Russian folk song “Korobeiniki,” transposed from E minor to A minor; accompaniment is original | [Wikimedia Commons 1861 score](https://commons.wikimedia.org/wiki/File:Korobeiniki.svg), marked Public Domain |
 
 Future quotations must identify the exact passage, use a verified public-domain
 score, and be reviewed independently from any modern recording or arrangement.

--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -20,7 +20,13 @@
         pong: { bpm: 126, root: 43, scale: [0,2,5,7,9], melody: [0,3,2,4,3,1,2,4,5,3,1,4,2,5,4,2,0,2,3,5,4,2,1,3,5,4,2,3,1,4,2,0], rhythm: [2,1,1,0,2,1,0,1,2,1,1,1,2,0,1,1], bass: [0,7,5,9,0,7,5,2], chords: [[0,4,7],[7,11,14],[5,9,12],[9,12,16]], swing: .1 },
         tictactoe: { bpm: 98, root: 50, scale: [0,2,3,7,9], melody: [0,null,2,3,4,3,null,1,0,2,3,null,4,5,2,1,0,2,null,4,3,1,2,4,5,3,1,null,4,2,1,0], rhythm: [2,0,1,1,2,1,0,1,2,1,1,0,2,1,0,1], bass: [0,3,7,2,0,9,7,3], chords: [[0,3,7],[3,7,10],[7,10,14],[2,5,9]], swing: .16 },
         battletanks: { bpm: 114, root: 38, scale: [0,2,3,7,8], melody: [0,2,3,1,4,3,2,1,0,3,4,2,1,4,5,3,0,2,4,3,5,4,2,1,3,5,4,2,1,3,2,0], rhythm: [2,0,1,1,2,1,1,0,2,1,0,1,2,1,1,1], bass: [0,3,8,7,0,10,8,7], chords: [[0,3,7],[3,7,10],[8,12,15],[7,10,14]], swing: .06 },
-        tetris: { bpm: 124, root: 45, scale: [0,2,3,5,7,8,10], melody: [0,2,4,3,5,4,6,2,0,3,5,1,4,6,3,2,7,5,3,4,6,5,2,4,0,2,5,3,6,4,2,1], rhythm: [2,1,1,0,2,1,1,1,2,0,1,1,2,1,0,1], bass: [0,5,3,7,0,8,7,10], chords: [[0,3,7],[5,8,12],[3,7,10],[7,10,14]], swing: .04 }
+        tetris: {
+            bpm: 132, root: 45, scale: [0,2,3,5,7,8,10], phrased: true,
+            melody: [7,null,4,5,6,null,5,4,3,null,3,5,7,null,6,5,4,null,null,5,6,null,7,null,5,null,3,null,3,null,null,null,6,null,null,8,10,null,9,8,7,null,null,5,7,null,6,5,4,null,4,5,6,null,7,null,5,null,3,null,3,null,null,null],
+            rhythm: [2,0,1,1,2,0,1,1,2,0,1,1,2,0,1,1,3,0,0,1,2,0,2,0,2,0,2,0,4,0,0,0,3,0,0,1,2,0,1,1,3,0,0,1,2,0,1,1,2,0,1,1,2,0,2,0,2,0,2,0,4,0,0,0],
+            bass: [0,0,0,0,0,0,0,0,7,7,7,7,0,0,0,0,5,5,5,5,0,0,0,0,7,7,7,7,0,0,0,0],
+            chords: [[0,3,7],[0,3,7],[7,11,14],[0,3,7],[5,8,12],[0,3,7],[7,11,14],[0,3,7]], swing: .04
+        }
     });
     const TIMBRES = Object.freeze({
         playful: { music: 'triangle', lead: 'sine', effects: 'triangle', attack: .008, release: .16, brightness: 2800, density: 1, gain: 1 },
@@ -165,7 +171,8 @@
         const rhythm = track.rhythm[index % track.rhythm.length];
         if (degree !== null && rhythm > 0 && (rhythm > 1 || intensity > .28) && (timbre.density >= 1 || index % 4 === 0)) {
             const midi = scaleMidi(track, degree, 12);
-            tone({ midi, at, duration: beat * (rhythm > 1 ? .82 : .52), gain: .04 + intensity * .022, type: timbre.lead, bus: musicBus, isMusic: true });
+            const duration = track.phrased ? beat * Math.max(.52, rhythm - .18) : beat * (rhythm > 1 ? .82 : .52);
+            tone({ midi, at, duration, gain: .04 + intensity * .022, type: timbre.lead, bus: musicBus, isMusic: true });
         }
         if (index % 2 === 0) {
             const bass = track.root + track.bass[Math.floor(index / 2) % track.bass.length];

--- a/scripts/audio.js
+++ b/scripts/audio.js
@@ -169,7 +169,8 @@
         const track = TRACKS[game], timbre = currentTimbre(), intensity = clamp(sceneDetail.intensity ?? .35), danger = clamp(sceneDetail.danger ?? 0);
         const degree = track.melody[index % track.melody.length];
         const rhythm = track.rhythm[index % track.rhythm.length];
-        if (degree !== null && rhythm > 0 && (rhythm > 1 || intensity > .28) && (timbre.density >= 1 || index % 4 === 0)) {
+        const melodyAllowed = track.phrased || ((rhythm > 1 || intensity > .28) && (timbre.density >= 1 || index % 4 === 0));
+        if (degree !== null && rhythm > 0 && melodyAllowed) {
             const midi = scaleMidi(track, degree, 12);
             const duration = track.phrased ? beat * Math.max(.52, rhythm - .18) : beat * (rhythm > 1 ? .82 : .52);
             tone({ midi, at, duration, gain: .04 + intensity * .022, type: timbre.lead, bus: musicBus, isMusic: true });

--- a/tests/audio-system.test.js
+++ b/tests/audio-system.test.js
@@ -92,15 +92,16 @@ test('the active music scene schedules melody, moving bass, harmony, and a beat 
     assert.ok(new Set(context.oscillators.map(source => source.frequency.value)).size >= 5, 'the arrangement should contain distinct harmonic voices');
 });
 
-test('the Tetris track opens with the transcribed Korobeiniki melody', async () => {
+test('the Tetris track preserves the Korobeiniki phrase at starting intensity in Calm mode', async () => {
     FakeAudioContext.instances.length = 0;
     const { env, intervals } = environment();
+    env.document.documentElement.dataset.arcadeTheme = 'calm';
     const audio = createArcadeAudio(env);
-    audio.setScene('active', { intensity: .5 });
+    audio.setScene('active', { intensity: .2 });
     await audio.activate();
     const context = FakeAudioContext.instances[0], schedule = intervals.values().next().value;
     for (let step = 0; step < 34; step += 1) { context.currentTime += .26; schedule(); }
-    const melody = context.oscillators.filter(source => source.type === 'sine' && source.frequency.value > 100).map(source => source.frequency.value);
+    const melody = context.oscillators.filter(source => source.type === 'triangle' && source.frequency.value > 100).map(source => source.frequency.value);
     const expected = [69,64,65,67,65,64,62,62,65,69,67,65,64,65,67,69,65,62,62].map(midi => 440 * Math.pow(2, (midi - 69) / 12));
     assert.deepEqual(melody.slice(0, expected.length).map(value => Math.round(value * 1000)), expected.map(value => Math.round(value * 1000)));
 });

--- a/tests/audio-system.test.js
+++ b/tests/audio-system.test.js
@@ -92,6 +92,19 @@ test('the active music scene schedules melody, moving bass, harmony, and a beat 
     assert.ok(new Set(context.oscillators.map(source => source.frequency.value)).size >= 5, 'the arrangement should contain distinct harmonic voices');
 });
 
+test('the Tetris track opens with the transcribed Korobeiniki melody', async () => {
+    FakeAudioContext.instances.length = 0;
+    const { env, intervals } = environment();
+    const audio = createArcadeAudio(env);
+    audio.setScene('active', { intensity: .5 });
+    await audio.activate();
+    const context = FakeAudioContext.instances[0], schedule = intervals.values().next().value;
+    for (let step = 0; step < 34; step += 1) { context.currentTime += .26; schedule(); }
+    const melody = context.oscillators.filter(source => source.type === 'sine' && source.frequency.value > 100).map(source => source.frequency.value);
+    const expected = [69,64,65,67,65,64,62,62,65,69,67,65,64,65,67,69,65,62,62].map(midi => 440 * Math.pow(2, (midi - 69) / 12));
+    assert.deepEqual(melody.slice(0, expected.length).map(value => Math.round(value * 1000)), expected.map(value => Math.round(value * 1000)));
+});
+
 test('melodies advance an octave for every complete scale traversal', async () => {
     FakeAudioContext.instances.length = 0;
     const { env, intervals } = environment({ pathname: '/Sudoku/' });
@@ -224,7 +237,8 @@ test('shared controls, provenance, ADR, and design boundaries are documented', (
     assert.match(read('docs/adr/0015-audible-sound-mixer.md'), /amends ADR 0013|open-dialog lifecycle/);
     assert.match(read('docs/audio-design.md'), /32-voice ceiling/);
     assert.match(read('docs/game-events.md'), /Producer rules/);
-    assert.match(read('docs/audio.md'), /Public-domain milestone fragments/);
+    assert.match(read('docs/audio.md'), /Public-domain quotations[\s\S]*Korobeiniki/);
+    assert.match(read('docs/adr/0020-tetris-korobeiniki-music.md'), /public-domain 1861 score/);
     assert.match(read('service-worker.js'), /scripts\/audio\.js/);
 });
 


### PR DESCRIPTION
## Summary
- replace the original Tetris lead with a synthesized eight-bar Korobeiniki melody
- preserve the asset-free audio engine with original bass, harmony, and percussion
- document public-domain provenance and the architectural exception
- add a regression test for the opening melodic phrase

## Verification
- node --test (253 passing)
- syntax checks equivalent to npm run check
- git diff --check