### PR TITLE
Add release branch ruleset template

### DIFF
--- a/.github/rulesets/release.json
+++ b/.github/rulesets/release.json
@@ -1,0 +1,50 @@
+{
+  "name": "Protect release promotions",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/release"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "merge"
+        ],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "test"
+          },
+          {
+            "context": "build"
+          }
+        ],
+        "strict_required_status_checks_policy": false
+      }
+    }
+  ]
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -152,6 +152,28 @@ carefully configured updater if stable should pull and restart automatically.
 - Send urgent fixes through the same `master` → alpha test → promotion pull
   request → `release` workflow. Do not bypass the release train.
 
+The repository includes an API-ready release branch ruleset at
+`.github/rulesets/release.json`. It assumes a solo maintainer, so it requires a
+pull request and resolved conversations but zero approving reviews. Increase
+`required_approving_review_count` to `1` when another maintainer is available to
+approve promotions. It permits only merge commits, preserving the exact
+alpha-tested `master` commits in `release`, and intentionally uses loose status
+checks so the long-lived branches do not have to merge each other's promotion
+commits.
+
+After the `release` branch exists, an administrator can create the ruleset with
+GitHub CLI:
+
+```sh
+gh api --method POST repos/OWNER/REPOSITORY/rulesets \
+  --input .github/rulesets/release.json
+```
+
+The file activates the ruleset immediately. Review it before submitting the
+request, especially if the repository is no longer maintained by one person.
+Creating it through the API is a one-time operation; subsequent changes should
+update the created ruleset rather than create a duplicate.
+
 The architectural rationale is recorded in
 [ADR 0026](adr/0026-controlled-release-trains.md). The workflow implementations
 are `.github/workflows/container.yml` and `.github/workflows/release.yml`.

--- a/tests/supply-chain.test.js
+++ b/tests/supply-chain.test.js
@@ -78,6 +78,22 @@ test('release operations are documented with the promotion and deployment model'
     assert.match(decision, /retry dispatched from an existing version tag[\s\S]*immutable full-version and SHA/);
 });
 
+test('release branch ruleset requires pull-requested, tested, non-destructive promotions', () => {
+    const ruleset = JSON.parse(fs.readFileSync('.github/rulesets/release.json', 'utf8'));
+    assert.equal(ruleset.target, 'branch');
+    assert.equal(ruleset.enforcement, 'active');
+    assert.deepEqual(ruleset.bypass_actors, []);
+    assert.deepEqual(ruleset.conditions.ref_name, { include: ['refs/heads/release'], exclude: [] });
+    const rules = Object.fromEntries(ruleset.rules.map(rule => [rule.type, rule.parameters || null]));
+    assert.ok('deletion' in rules);
+    assert.ok('non_fast_forward' in rules);
+    assert.deepEqual(rules.pull_request.allowed_merge_methods, ['merge']);
+    assert.equal(rules.pull_request.required_approving_review_count, 0);
+    assert.equal(rules.pull_request.required_review_thread_resolution, true);
+    assert.deepEqual(rules.required_status_checks.required_status_checks, [{ context: 'test' }, { context: 'build' }]);
+    assert.equal(rules.required_status_checks.strict_required_status_checks_policy, false);
+});
+
 test('Dependabot checks every build dependency ecosystem daily', () => {
     const configuration = fs.readFileSync('.github/dependabot.yml', 'utf8');
     const ecosystems = [...configuration.matchAll(/^\s*- package-ecosystem:\s*(\S+)$/gm)].map(match => match[1]);


### PR DESCRIPTION
## Summary
- add an API-ready active ruleset for the release branch
- require pull requests, resolved discussions, and passing test/build checks
- prevent deletion and force pushes while preserving the promotion topology
- document how to apply and maintain the ruleset

## Verification
- node --test
- node scripts/release-notes.js validate
- git diff --check